### PR TITLE
Add Speed & Battery reporting functionality as well as voltage-based battery percent determination.

### DIFF
--- a/OWCE/OWCE.Android/DependencyImplementations/OWBLE.cs
+++ b/OWCE/OWCE.Android/DependencyImplementations/OWBLE.cs
@@ -129,7 +129,7 @@ namespace OWCE.Droid.DependencyImplementations
 
             public override void OnConnectionStateChange(BluetoothGatt gatt, GattStatus status, ProfileState newState)
             {
-                Debug.WriteLine("OnConnectionStateChange: " + status);
+                Debug.WriteLine($"OnConnectionStateChange: status {status} newState {newState}.");
                 _owble.OnConnectionStateChange(gatt, status, newState);
             }
 
@@ -586,7 +586,10 @@ namespace OWCE.Droid.DependencyImplementations
 
         public Task Disconnect()
         {
-            if (_connectTaskCompletionSource != null && _connectTaskCompletionSource.Task.IsCanceled == false)
+            if (_connectTaskCompletionSource != null
+                && !_connectTaskCompletionSource.Task.IsCompleted
+                && !_connectTaskCompletionSource.Task.IsCanceled
+                && !_connectTaskCompletionSource.Task.IsFaulted)
             {
                 _connectTaskCompletionSource.SetCanceled();
             }

--- a/OWCE/OWCE/App.xaml.cs
+++ b/OWCE/OWCE/App.xaml.cs
@@ -42,10 +42,70 @@ namespace OWCE
             typeof(App),
             false);
 
+        public static readonly BindableProperty SpeedReportingProperty = BindableProperty.Create(
+            nameof(SpeedReporting),
+            typeof(bool),
+            typeof(App),
+            false);
+
+        public static readonly BindableProperty SpeedReportingBaselineTimeoutProperty = BindableProperty.Create(
+            nameof(SpeedReportingBaselineTimeout),
+            typeof(int),
+            typeof(App),
+            15);
+
+        public static readonly BindableProperty SpeedReportingMinimumProperty = BindableProperty.Create(
+            nameof(SpeedReportingMinimum),
+            typeof(int),
+            typeof(App),
+            10);
+
+        public static readonly BindableProperty BatteryPercentReportingProperty = BindableProperty.Create(
+            nameof(BatteryPercentReporting),
+            typeof(bool),
+            typeof(App),
+            false);
+
+        public static readonly BindableProperty BatteryPercentInferredBasedOnVoltageProperty = BindableProperty.Create(
+            nameof(BatteryPercentInferredBasedOnVoltage),
+            typeof(bool),
+            typeof(App),
+            false);
+
         public bool MetricDisplay
         {
             get { return (bool)GetValue(MetricDisplayProperty); }
             set { SetValue(MetricDisplayProperty, value); }
+        }
+
+        public bool SpeedReporting
+        {
+            get { return (bool)GetValue(SpeedReportingProperty); }
+            set { SetValue(SpeedReportingProperty, value); }
+        }
+
+        public int SpeedReportingBaselineTimeout
+        {
+            get { return (int)GetValue(SpeedReportingBaselineTimeoutProperty); }
+            set { SetValue(SpeedReportingBaselineTimeoutProperty, value); }
+        }
+
+        public int SpeedReportingMinimum
+        {
+            get { return (int)GetValue(SpeedReportingMinimumProperty); }
+            set { SetValue(SpeedReportingMinimumProperty, value); }
+        }
+
+        public bool BatteryPercentReporting
+        {
+            get { return (bool)GetValue(BatteryPercentReportingProperty); }
+            set { SetValue(BatteryPercentReportingProperty, value); }
+        }
+
+        public bool BatteryPercentInferredBasedOnVoltage
+        {
+            get { return (bool)GetValue(BatteryPercentInferredBasedOnVoltageProperty); }
+            set { SetValue(BatteryPercentInferredBasedOnVoltageProperty, value); }
         }
 
         public string LogsDirectory => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "beta_ride_logs");
@@ -54,8 +114,12 @@ namespace OWCE
         {
             Xamarin.Forms.Device.SetFlags(new string[] { "Shapes_Experimental", "Expander_Experimental" });
 
-
             MetricDisplay = Preferences.Get("metric_display", System.Globalization.RegionInfo.CurrentRegion.IsMetric);
+            SpeedReporting = Preferences.Get("speed_reporting", false);
+            SpeedReportingBaselineTimeout = Preferences.Get("speedreporting_baseline_timeout", 15);
+            SpeedReportingMinimum = Preferences.Get("speedreporting_minimum", System.Globalization.RegionInfo.CurrentRegion.IsMetric ? 15 : 10);
+            BatteryPercentReporting = Preferences.Get("batterypercent_reporting", false);
+            BatteryPercentInferredBasedOnVoltage = Preferences.Get("batterypercent_inferred_voltage", false);
             
             if (Directory.Exists(LogsDirectory) == false)
             {

--- a/OWCE/OWCE/BatteryPercentReporting.cs
+++ b/OWCE/OWCE/BatteryPercentReporting.cs
@@ -1,0 +1,80 @@
+﻿namespace OWCE
+{
+    using OWCE.Converters;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Threading;
+    using Xamarin.Essentials;
+
+    public class BatteryPercentReporting : TTSReporting
+    {
+        private readonly TimeSpan GapTimeReport = TimeSpan.FromSeconds(3);
+        private readonly TimeSpan GapTimeReportSameValue = TimeSpan.FromMinutes(5);
+
+        private bool _running = false;
+        private DateTime _nextReportTime = DateTime.Now;
+        private OWBoard _board;
+        private Dictionary<int, DateTime> _announcedValues = new Dictionary<int, DateTime>();
+
+        public BatteryPercentReporting(OWBoard board, TextToSpeechProvider ttsProvider) : base(ttsProvider)
+        {
+            _board = board;
+            TextToSpeechPriority = 3;
+
+            Debug.WriteLine($"Battery Percent Reporting created for board {board.Name}");
+        }
+
+        public override void Start()
+        {
+            if (_running)
+            {
+                return;
+            }
+
+            System.Diagnostics.Debug.WriteLine("ACTIVATED Battery Percent detector");
+
+            _board.BatteryPercentChanged += Board_BatteryPercentChanged;
+        }
+
+        public override void Stop()
+        {
+            if (!_running)
+            {
+                return;
+            }
+
+            _board.BatteryPercentChanged -= Board_BatteryPercentChanged;
+
+            _running = false;
+
+            System.Diagnostics.Debug.WriteLine("DEACTIVATED Battery Percent detector");
+        }
+
+        private void Board_BatteryPercentChanged(object sender, BatteryPercentChangedEventArgs e)
+        {
+            var currentTime = DateTime.Now;
+
+            if (currentTime > _nextReportTime
+                && ShouldAnnounceValue(e.batteryPercentValue))
+            {
+                if (_announcedValues.ContainsKey(e.batteryPercentValue)
+                    && _announcedValues[e.batteryPercentValue] > currentTime)
+                {
+                    System.Diagnostics.Debug.WriteLine($"Skipping announcement for Battery Percent detector: {e.batteryPercentValue} percent.");
+                    return; // Too soon to announce same value
+                }
+
+                _announcedValues[e.batteryPercentValue] = currentTime + GapTimeReportSameValue;
+                _nextReportTime = currentTime + GapTimeReport;
+
+                SpeakMessage($"Battery update: {e.batteryPercentValue} percent.");
+            }
+        }
+
+        private bool ShouldAnnounceValue(int batteryPercent)
+        {
+            return batteryPercent % 10 == 0;
+        }
+    }
+}

--- a/OWCE/OWCE/Converters/BatteryVoltageConverter.cs
+++ b/OWCE/OWCE/Converters/BatteryVoltageConverter.cs
@@ -1,0 +1,95 @@
+﻿namespace OWCE.Converters
+{
+    using OWCE.Extensions;
+    using OWCE.Spline;
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using Xamarin.Forms;
+
+    public class BatteryVoltageConverter : IValueConverter
+    {
+        private static Tuple<float, float>[] CBVoltageMapping = new Tuple<float, float>[]
+        {
+            new Tuple<float, float>(62.25f, 100f),
+            new Tuple<float, float>(60.75f, 93f),
+            new Tuple<float, float>(60f, 86f),
+            new Tuple<float, float>(58.8f, 79f),
+            new Tuple<float, float>(57.75f, 72f),
+            new Tuple<float, float>(56.7f, 65f),
+            new Tuple<float, float>(55.5f, 58f),
+            new Tuple<float, float>(54.75f, 51f),
+            new Tuple<float, float>(54f, 44f),
+            new Tuple<float, float>(52.95f, 37f),
+            new Tuple<float, float>(51.75f, 30f),
+            new Tuple<float, float>(51f, 23f),
+            new Tuple<float, float>(48f, 16f),
+            new Tuple<float, float>(45f, 9f),
+            new Tuple<float, float>(43.5f, 0f)
+        };
+
+        private static Lazy<List<Tuple<float, float>>> _voltageMap = new Lazy<List<Tuple<float, float>>>(() =>
+        {
+            float[] fxArray = CBVoltageMapping.Select(t => t.Item1).ToArray();
+            float[] fyArray = CBVoltageMapping.Select(t => t.Item2).ToArray();
+
+            float[] xs;
+            float[] ys;
+            CubicSpline.FitParametric(fxArray, fyArray, StepsPrecisionCount, out xs, out ys);
+
+            SortPairInplace(xs, ys);
+
+            var voltageMap = new List<Tuple<float, float>>();
+            for (int i = 0; i < xs.Length; ++i)
+            {
+                voltageMap.Add(new Tuple<float, float>(xs[i], ys[i]));
+            }
+
+            return voltageMap;
+        });
+
+        private const int StepsPrecisionCount = 1000;
+
+        public BatteryVoltageConverter()
+        {
+        }
+
+        public static int GetBatteryPercentEstimate(float voltage)
+        {
+            return (int)(_voltageMap.Value.BinarySearchClosestBind(i => i.Item1, voltage).Item2);
+        }
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is float voltageValue)
+            {
+                int percentageValue = GetBatteryPercentEstimate(voltageValue);
+                return $"{percentageValue}%";
+            }
+
+            return "Unknown";
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static void SortPairInplace<T>(T[] xArray, T[] yArray) where T : IComparable
+        {
+            var indexList = new List<Tuple<T, T>>();
+            for (int i = 0; i < xArray.Length; ++i)
+            {
+                indexList.Add(new Tuple<T, T>(xArray[i], yArray[i]));
+            }
+
+            indexList = indexList.OrderBy(kv => kv.Item2).ToList();
+            for (int i = 0; i < indexList.Count; ++i)
+            {
+                xArray[i] = indexList[i].Item1;
+                yArray[i] = indexList[i].Item2;
+            }
+        }
+    }
+}

--- a/OWCE/OWCE/Converters/RpmToSpeedConverter.cs
+++ b/OWCE/OWCE/Converters/RpmToSpeedConverter.cs
@@ -17,17 +17,9 @@ namespace OWCE.Converters
         {
             if (value is int rpm) // && parameter is float wheelCircumfrence)
             {
-                // TODO: Not use static wheel circumfrence. 
-                var metersPerSecond = 917.66f * rpm * MillimetersPerMinuteToMetersPerSecond;
-                
-                if (App.Current.MetricDisplay)
-                {
-                    return metersPerSecond * 3.6f; // kmph
-                }
-                else
-                {
-                    return metersPerSecond * 2.23694f; // mph
-                }
+                // TODO: Not use static wheel circumfrence. This converter is not currently being used for UI or reporting.
+                float wheelCircumference = 917.66f;
+                return ConvertSpeedValueFromRpm(rpm, wheelCircumference, App.Current.MetricDisplay);
             }
 
             return 0.0f;
@@ -36,6 +28,20 @@ namespace OWCE.Converters
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
             throw new NotImplementedException();
+        }
+
+        public static float ConvertSpeedValueFromRpm(int rpm, float wheelCircumference, bool isMetric)
+        {
+            var metersPerSecond = wheelCircumference * (float)rpm * MillimetersPerMinuteToMetersPerSecond;
+
+            if (isMetric)
+            {
+                return metersPerSecond * 3.6f; // kmph
+            }
+            else
+            {
+                return metersPerSecond * 2.23694f; // mph
+            }
         }
     }
 }

--- a/OWCE/OWCE/Converters/SpeedConverter.cs
+++ b/OWCE/OWCE/Converters/SpeedConverter.cs
@@ -11,14 +11,7 @@ namespace OWCE.Converters
             var outputValue = 0f;
             if (value is float metersPerSecond)
             {
-                if (App.Current.MetricDisplay)
-                {
-                    outputValue = metersPerSecond * 3.6f; // kmph
-                }
-                else
-                {
-                    outputValue = metersPerSecond * 2.23694f; // mph
-                }
+                outputValue = ConvertSpeedValue(metersPerSecond, App.Current.MetricDisplay);
             }
 
             if (parameter == null)
@@ -38,6 +31,18 @@ namespace OWCE.Converters
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
             throw new NotImplementedException();
+        }
+
+        public static float ConvertSpeedValue(float metersPerSecond, bool isMetric)
+        {
+            if (isMetric)
+            {
+                return metersPerSecond * 3.6f; // kmph
+            }
+            else
+            {
+                return metersPerSecond * 2.23694f; // mph
+            }
         }
     }
 }

--- a/OWCE/OWCE/Extensions/ListExtension.cs
+++ b/OWCE/OWCE/Extensions/ListExtension.cs
@@ -1,0 +1,50 @@
+﻿namespace OWCE.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    public static class ListExtension
+    {
+        public static T BinarySearchClosestBind<T, TKey>(this IList<T> list, Func<T, TKey> keySelector, TKey key)
+            where TKey : IComparable<TKey>
+        {
+            if (list.Count == 0)
+            {
+                throw new InvalidOperationException("Empty list; Item not found");
+            }
+
+            int min = 0;
+            int max = list.Count;
+
+            while (min < max)
+            {
+                int mid = min + ((max - min) / 2);
+                T midItem = list[mid];
+                TKey midKey = keySelector(midItem);
+                int comp = midKey.CompareTo(key);
+
+                if (comp < 0)
+                {
+                    min = mid + 1;
+                }
+                else if (comp > 0)
+                {
+                    max = mid - 1;
+                }
+                else
+                {
+                    return midItem;
+                }
+            }
+
+            if (min < list.Count)
+            {
+                return list[min];
+            }
+            else
+            {
+                return list[max - 1];
+            }
+        }
+    }
+}

--- a/OWCE/OWCE/OWBoard.cs
+++ b/OWCE/OWCE/OWBoard.cs
@@ -47,6 +47,20 @@ namespace OWCE
         public const int Pint_Skyline = 8;
     }
 
+    public class BatteryPercentChangedEventArgs : EventArgs
+    {
+        public int batteryPercentValue;
+    }
+
+    public delegate void BatteryPercentChangedEventHandler(object sender, BatteryPercentChangedEventArgs e);
+
+    public class SpeedChangedEventArgs : EventArgs
+    {
+        public float speedValue;
+    }
+
+    public delegate void SpeedChangedEventHandler(object sender, SpeedChangedEventArgs e);
+
     public class OWBoard : OWBaseBoard
     {
         public static readonly Guid ServiceUUID = new Guid("E659F300-EA98-11E3-AC10-0800200C9A66");
@@ -85,6 +99,9 @@ namespace OWCE
         public const string UNKNOWN3UUID = "E659F31F-EA98-11E3-AC10-0800200C9A66";
         public const string UNKNOWN4UUID = "E659F320-EA98-11E3-AC10-0800200C9A66";
 
+        public event BatteryPercentChangedEventHandler BatteryPercentChanged;
+        public event SpeedChangedEventHandler SpeedChanged;
+
         private int _serialNumber;
         public int SerialNumber
         {
@@ -92,11 +109,66 @@ namespace OWCE
             set { if (_serialNumber != value) { _serialNumber = value; OnPropertyChanged(); } }
         }
 
+        private int _selectedBatteryPercent;
+        public int SelectedBatteryPercent
+        {
+            get { return _selectedBatteryPercent; }
+            set
+            {
+                if (_selectedBatteryPercent == value)
+                {
+                    return;
+                }
+
+                _selectedBatteryPercent = value;
+                OnPropertyChanged();
+
+                var changedArgs = new BatteryPercentChangedEventArgs();
+                changedArgs.batteryPercentValue = value;
+                OnBatteryPercentChanged(changedArgs);
+            }
+        }
+
         private int _batteryPercent;
         public int BatteryPercent
         {
             get { return _batteryPercent; }
-            set { if (_batteryPercent != value) { _batteryPercent = value; OnPropertyChanged(); } }
+            set
+            {
+                if (_batteryPercent == value)
+                {
+                    return;
+                }
+
+                _batteryPercent = value;
+                OnPropertyChanged();
+
+                if (!App.Current.BatteryPercentInferredBasedOnVoltage)
+                {
+                    SelectedBatteryPercent = BatteryPercent;
+                }
+            }
+        }
+
+        private int _batteryPercentInferredFromVoltage;
+        public int BatteryPercentInferredFromVoltage
+        {
+            get { return _batteryPercentInferredFromVoltage; }
+            set
+            {
+                if (_batteryPercentInferredFromVoltage == value)
+                {
+                    return;
+                }
+
+                _batteryPercentInferredFromVoltage = value;
+                OnPropertyChanged();
+
+                if (App.Current.BatteryPercentInferredBasedOnVoltage)
+                {
+                    SelectedBatteryPercent = BatteryPercentInferredFromVoltage;
+                }
+            }
         }
 
         private int _batteryLow5;
@@ -235,7 +307,24 @@ namespace OWCE
         public float BatteryVoltage
         {
             get { return _batteryVoltage; }
-            set { if (_batteryVoltage.AlmostEqualTo(value) == false) { _batteryVoltage = value; OnPropertyChanged(); } }
+            set
+            {
+                if (_batteryVoltage.AlmostEqualTo(value))
+                {
+                    return;
+                }
+
+                _batteryVoltage = value;
+                OnPropertyChanged();
+
+                if (_voltageAggregator != null)
+                {
+                    _voltageAggregator.AppendVoltageEntry(value);
+
+                    float medianVoltage = _voltageAggregator.GetMedianVoltage();
+                    BatteryPercentInferredFromVoltage = Converters.BatteryVoltageConverter.GetBatteryPercentEstimate(medianVoltage);
+                }
+            }
         }
 
         private int _safetyHeadroom;
@@ -284,7 +373,20 @@ namespace OWCE
         public float Speed
         {
             get { return _speed; }
-            set { if (_speed.AlmostEqualTo(value) == false) { _speed = value; OnPropertyChanged(); } }
+            set
+            {
+                if (_speed.AlmostEqualTo(value))
+                {
+                    return;
+                }
+
+                _speed = value;
+                OnPropertyChanged();
+
+                var speedArgs = new SpeedChangedEventArgs();
+                speedArgs.speedValue = value;
+                OnSpeedChanged(speedArgs);
+            }
         }
 
         private ushort _hardwareRevision;
@@ -446,10 +548,6 @@ namespace OWCE
         }
         */
 
-
-
-
-
         private bool _lightMode = false;
         public bool LightMode
         {
@@ -506,20 +604,20 @@ namespace OWCE
             set { if (_rssi != value) { _rssi = value; OnPropertyChanged(); } }
         }
 
-        IOWBLE _owble;
+        private IOWBLE _owble;
 
-        bool _isLogging = false;
-        OWBoardEventList _events = new OWBoardEventList();
-        List<OWBoardEvent> _initialEvents;
-        Ride _currentRide = null;
-        bool _keepHandshakeBackgroundRunning = false;
-        List<byte> _handshakeBuffer = null;
-        bool _isHandshaking = false;
-        TaskCompletionSource<byte[]> _handshakeTaskCompletionSource = null;
+        private bool _isLogging = false;
+        private OWBoardEventList _events = new OWBoardEventList();
+        private List<OWBoardEvent> _initialEvents;
+        private Ride _currentRide = null;
+        private bool _keepHandshakeBackgroundRunning = false;
+        private List<byte> _handshakeBuffer = null;
+        private bool _isHandshaking = false;
+        private TaskCompletionSource<byte[]> _handshakeTaskCompletionSource = null;
+        private VoltageAggregator _voltageAggregator = new VoltageAggregator();
 
         public OWBoard(IOWBLE owble, OWBaseBoard baseBoard) : base(baseBoard)
         {
-
             _owble = owble;
             _id = baseBoard.ID;
             _name = baseBoard.Name;
@@ -553,6 +651,26 @@ namespace OWCE
                 StartLogging();
             }
 #endif
+
+#if DEBUG
+            MockSetup();
+#endif
+        }
+
+        private void OnBatteryPercentChanged(BatteryPercentChangedEventArgs e)
+        {
+            if (BatteryPercentChanged != null)
+            {
+                BatteryPercentChanged(this, e);
+            }
+        }
+
+        private void OnSpeedChanged(SpeedChangedEventArgs e)
+        {
+            if (SpeedChanged != null)
+            {
+                SpeedChanged(this, e);
+            }
         }
 
         void LogData(string characteristicGuid, byte[] data)
@@ -614,6 +732,37 @@ namespace OWCE
             RSSI = rssi;
         }
 
+#if DEBUG
+        static bool _enableMockBatteryPercentage = false; // Enable this to walk through battery % values
+        private bool _mockSetupHasBeenEnabledForThisBoard = false;
+
+        private void MockSetup()
+        {
+            if (_enableMockBatteryPercentage && !_mockSetupHasBeenEnabledForThisBoard)
+            {
+                _mockSetupHasBeenEnabledForThisBoard = true;
+                StartMockBatteryChangeTimer();
+            }
+        }
+
+        static int _mockBatteryPercent = 100;
+        static float _mockBatteryVoltage = 63.1f;
+        private Timer _mockBatteryPercentChangeTimer;
+        private void StartMockBatteryChangeTimer()
+        {
+            _mockBatteryPercentChangeTimer = new Timer((object state) =>
+            {
+                if (App.Current.BatteryPercentInferredBasedOnVoltage)
+                {
+                    BatteryVoltage = (_mockBatteryVoltage -= 0.1f);
+                }
+                else
+                {
+                    BatteryPercent = _mockBatteryPercent-- % 100;
+                }
+            }, null, 0, 1500);
+        }
+#endif // DEBUG
 
         // TODO: Restore, Dictionary<string, ICharacteristic> _characteristics = new Dictionary<string, ICharacteristic>();
 
@@ -1163,6 +1312,7 @@ namespace OWCE
                     break;
                 case RpmUUID:
                     RPM = value;
+                    Speed = Converters.RpmToSpeedConverter.ConvertSpeedValueFromRpm(value, WheelCircumference, App.Current.MetricDisplay);
                     break;
                 case RideModeUUID:
                     RideMode = value;

--- a/OWCE/OWCE/OWCE.csproj
+++ b/OWCE/OWCE/OWCE.csproj
@@ -30,6 +30,7 @@
 
 
   <ItemGroup>
+    <Folder Include="Spline\" />
     <Folder Include="Pages\" />
     <Folder Include="Extensions\" />
     <Folder Include="Views\" />

--- a/OWCE/OWCE/Pages/BoardPage.xaml
+++ b/OWCE/OWCE/Pages/BoardPage.xaml
@@ -30,18 +30,24 @@
                 <Grid Grid.Row="2" RowDefinitions="30,30,30,30" ColumnDefinitions="53,*" Margin="16,20,16,8">
                     <views:SettingsSwitch x:Name="ImperialSwitch" Grid.Row="0" Grid.Column="0" IsToggledChanged="ImperialSwitch_IsToggledChanged" />
                     <Label Grid.Row="0" Grid.Column="1" Text="Imperial units (mph, F)" FontFamily="SairaExtraCondensed-Bold" TextColor="{Binding Source={x:Reference ImperialSwitch}, Path=CurrentColor}" FontSize="18" />
-
-                    <views:SettingsSwitch Grid.Row="1" Grid.Column="0" />
-                    <Label Grid.Row="1" Grid.Column="1" Text="Light theme" FontFamily="SairaExtraCondensed-Bold" TextColor="Black" FontSize="18" />
-
-                    <views:SettingsSwitch Grid.Row="2" Grid.Column="0" />
-                    <Label Grid.Row="2" Grid.Column="1" Text="Board lights on" FontFamily="SairaExtraCondensed-Bold" TextColor="Black" FontSize="18" />
                     
-                    <views:SettingsSwitch Grid.Row="3" Grid.Column="0" />
-                    <Label Grid.Row="3" Grid.Column="1" Text="Show battery % calculation from voltage" FontFamily="SairaExtraCondensed-Bold" TextColor="Black" FontSize="18" />
+                    <views:SettingsSwitch x:Name="SpeedReportingSwitch" Grid.Row="1" Grid.Column="0" IsToggledChanged="SpeedReportingSwitch_IsToggledChanged" />
+                    <Label Grid.Row="1" Grid.Column="1" Text="Speed Alerts" FontFamily="SairaExtraCondensed-Bold" TextColor="{Binding Source={x:Reference SpeedReportingSwitch}, Path=CurrentColor}" FontSize="18" />
 
-                    <BoxView Color="White" Opacity="0.8" Grid.Row="1" Grid.Column="0" Grid.RowSpan="4" Grid.ColumnSpan="2" />
-                    <Label TextColor="Black" Grid.Row="1" Text="Coming Soon" HorizontalOptions="Center" VerticalOptions="Center" Grid.Column="0" Grid.RowSpan="4" Grid.ColumnSpan="2" FontFamily="SairaExtraCondensed-Bold" />
+                    <views:SettingsSwitch x:Name="BatteryPercentReportingSwitch" Grid.Row="2" Grid.Column="0" IsToggledChanged="BatteryPercentReportingSwitch_IsToggledChanged" />
+                    <Label Grid.Row="2" Grid.Column="1" Text="Battery Updates" FontFamily="SairaExtraCondensed-Bold" TextColor="{Binding Source={x:Reference BatteryPercentReportingSwitch}, Path=CurrentColor}" FontSize="18" />
+
+                    <views:SettingsSwitch x:Name="BatteryPercentInferredBasedOnVoltageSwitch" Grid.Row="3" Grid.Column="0" IsToggledChanged="BatteryPercentInferredBasedOnVoltageSwitch_IsToggledChanged" />
+                    <Label Grid.Row="3" Grid.Column="1" Text="Show battery % based on voltage" FontFamily="SairaExtraCondensed-Bold" TextColor="{Binding Source={x:Reference BatteryPercentInferredBasedOnVoltageSwitch}, Path=CurrentColor}" FontSize="18" />
+                    
+                    <views:SettingsSwitch Grid.Row="4" Grid.Column="0" />
+                    <Label Grid.Row="4" Grid.Column="1" Text="Light theme" FontFamily="SairaExtraCondensed-Bold" TextColor="Black" FontSize="18" />
+
+                    <views:SettingsSwitch Grid.Row="5" Grid.Column="0" />
+                    <Label Grid.Row="5" Grid.Column="1" Text="Board lights on" FontFamily="SairaExtraCondensed-Bold" TextColor="Black" FontSize="18" />
+
+                    <BoxView Color="White" Opacity="0.8" Grid.Row="4" Grid.Column="0" Grid.RowSpan="2" Grid.ColumnSpan="2" />
+                    <Label TextColor="Black" Grid.Row="4" Text="Coming Soon" HorizontalOptions="Center" VerticalOptions="Center" Grid.Column="0" Grid.RowSpan="2" Grid.ColumnSpan="2" FontFamily="SairaExtraCondensed-Bold" />
                 </Grid>
                 <BoxView Grid.Row="3" Background="#E4E4E4" HeightRequest="1" />
 
@@ -75,8 +81,8 @@
         </yummy:PancakeView>
         <ScrollView>
             <StackLayout Spacing="16" Margin="0,16,0,0">
-                <views:SpeedRangeDistanceView x:Name="SpeedRangeDistanceView" HeightRequest="180" RPM="{Binding RPM}" WheelCircumference="{Binding WheelCircumference}" LifetimeOdometer="{Binding LifetimeOdometer}" TripOdometer="{Binding TripOdometer}" />
-                <views:BatteryView BindingContext="{Binding .}" BatteryPercent="{Binding BatteryPercent}" BatteryVoltage="{Binding BatteryVoltage}" BatteryCells="{Binding BatteryCells}"  />
+                <views:SpeedRangeDistanceView x:Name="SpeedRangeDistanceView" HeightRequest="180" RPM="{Binding RPM}" Speed="{Binding Speed}" LifetimeOdometer="{Binding LifetimeOdometer}" TripOdometer="{Binding TripOdometer}" />
+                <views:BatteryView BindingContext="{Binding .}" BatteryPercent="{Binding SelectedBatteryPercent}" BatteryVoltage="{Binding BatteryVoltage}" BatteryCells="{Binding BatteryCells}"  />
                 <views:PowerView BindingContext="{Binding .}" CurrentAmps="{Binding CurrentAmps}" IsRegen="{Binding IsRegen}" TripAmpHours="{Binding TripAmpHours}" TripRegenAmpHours="{Binding TripRegenAmpHours}" />
                 <views:TemperatureView x:Name="TemperatureView" BindingContext="{Binding .}" ControllerTemp="{Binding ControllerTemperature}" MotorTemp="{Binding MotorTemperature}" BatteryTemp="{Binding BatteryTemperature}" />
                 <views:RideModeView BindingContext="{Binding .}" BoardType="{Binding BoardType}" SimpleStopEnabled="{Binding SimpleStopEnabled}" />

--- a/OWCE/OWCE/Pages/BoardPage.xaml.cs
+++ b/OWCE/OWCE/Pages/BoardPage.xaml.cs
@@ -1,24 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using Xamarin.Essentials;
-using Xamarin.Forms;
-using RestSharp;
-using System.Net;
-using System.IO;
-using System.Threading.Tasks;
-using OWCE.Pages.Popup;
-using Rg.Plugins.Popup.Services;
-using System.Linq;
-using OWCE.Views;
-
 namespace OWCE.Pages
 {
+    using System;
+    using System.Collections.Generic;
+    using Xamarin.Essentials;
+    using Xamarin.Forms;
+    using RestSharp;
+    using System.Net;
+    using System.IO;
+    using System.Threading.Tasks;
+    using OWCE.Pages.Popup;
+    using Rg.Plugins.Popup.Services;
+    using System.Linq;
+    using OWCE.Models;
+    using OWCE.Views;
+
     public partial class BoardPage : BaseContentPage
     {
         ConnectingAlert _reconnectingAlert;
 
-
         public OWBoard Board { get; private set; }
+
         /*
         public string SpeedHeader
         {
@@ -31,11 +32,17 @@ namespace OWCE.Pages
 
         private bool _initialSubscirbe = false;
 
-
+        private TextToSpeechProvider _ttsProvider = null;
+        private SpeedReporting _speedReporting = null;
+        private BatteryPercentReporting _batteryPercentReporting = null;
 
         public BoardPage(OWBoard board) : base()
         {
             Board = board;
+
+            board.Init();
+
+            BindingContext = this;
 
             //board.StartLogging();
             InitializeComponent();
@@ -44,6 +51,9 @@ namespace OWCE.Pages
             AppVersionLabel.Text = $"{AppInfo.VersionString} (build {AppInfo.BuildString})";
 
             ImperialSwitch.IsToggled = !App.Current.MetricDisplay;
+            SpeedReportingSwitch.IsToggled = App.Current.SpeedReporting;
+            BatteryPercentReportingSwitch.IsToggled = App.Current.BatteryPercentReporting;
+            BatteryPercentInferredBasedOnVoltageSwitch.IsToggled = App.Current.BatteryPercentInferredBasedOnVoltage;
 
 
             Board.Init();
@@ -70,6 +80,11 @@ namespace OWCE.Pages
                 }),
             };
             CustomToolbarItems.Add(settingsToolbarItem);
+
+            _ttsProvider = new TextToSpeechProvider();
+
+            UpdateSpeedReporting(App.Current.SpeedReporting);
+            UpdateBatteryPercentReporting(App.Current.BatteryPercentReporting);
         }
 
         private void OWBLE_BoardDisconnected()
@@ -87,13 +102,11 @@ namespace OWCE.Pages
                 PopupNavigation.Instance.RemovePageAsync(_reconnectingAlert);
                 _reconnectingAlert = null;
             }), "Reconnecting...");
-            
 
             if (PopupNavigation.Instance.PopupStack.Contains(_reconnectingAlert) == false)
             {
                 PopupNavigation.Instance.PushAsync(_reconnectingAlert, true);
             }
-
         }
 
 
@@ -141,7 +154,7 @@ namespace OWCE.Pages
             return false;
         }
 
-        async void Disconnect_Tapped(System.Object sender, System.EventArgs e)
+        async void Disconnect_Tapped(object sender, EventArgs e)
         {
             var result = await DisplayActionSheet("Are you sure you want to disconnect?", "Cancel", "Disconnect");
             if (result == "Disconnect")
@@ -153,8 +166,44 @@ namespace OWCE.Pages
 
         public async Task DisconnectAndPop()
         {
+            UpdateSpeedReporting(enabled: false);
+            UpdateBatteryPercentReporting(enabled: false);
+
+            if (_ttsProvider != null)
+            {
+                _ttsProvider.SpeakMessage("OWCE Status: Disconnecting", 3);
+            }
+
             await App.Current.OWBLE.Disconnect();
             await Navigation.PopModalAsync();
+        }
+
+        private void UpdateSpeedReporting(bool enabled)
+        {
+            if (enabled)
+            {
+                _speedReporting = new SpeedReporting(this.Board, _ttsProvider);
+                _speedReporting.Start();
+            }
+            else if (_speedReporting != null)
+            {
+                _speedReporting.Stop();
+                _speedReporting = null;
+            }
+        }
+
+        private void UpdateBatteryPercentReporting(bool enabled)
+        {
+            if (enabled)
+            {
+                _batteryPercentReporting = new BatteryPercentReporting(this.Board, _ttsProvider);
+                _batteryPercentReporting.Start();
+            }
+            else if (_batteryPercentReporting != null)
+            {
+                _batteryPercentReporting.Stop();
+                _batteryPercentReporting = null;
+            }
         }
 
         private bool _isLogging = false;
@@ -175,6 +224,29 @@ namespace OWCE.Pages
 
             //this.ForceLayout();
         }
+
+        private void SpeedReportingSwitch_IsToggledChanged(object sender, bool isToggled)
+        {
+            App.Current.SpeedReporting = isToggled;
+            Preferences.Set("speed_reporting", isToggled);
+
+            UpdateSpeedReporting(App.Current.SpeedReporting);
+        }
+
+        private void BatteryPercentReportingSwitch_IsToggledChanged(object sender, bool isToggled)
+        {
+            App.Current.BatteryPercentReporting = isToggled;
+            Preferences.Set("batterypercent_reporting", isToggled);
+
+            UpdateBatteryPercentReporting(App.Current.BatteryPercentReporting);
+        }
+
+        private void BatteryPercentInferredBasedOnVoltageSwitch_IsToggledChanged(object sender, bool isToggled)
+        {
+            App.Current.BatteryPercentInferredBasedOnVoltage = isToggled;
+            Preferences.Set("batterypercent_inferred_voltage", isToggled);
+        }
+
 
         /*
         private async void LogData_Clicked(object sender, System.EventArgs e)
@@ -248,6 +320,5 @@ namespace OWCE.Pages
 
         }
         */
-
     }
 }

--- a/OWCE/OWCE/Pages/SettingsPage.xaml
+++ b/OWCE/OWCE/Pages/SettingsPage.xaml
@@ -8,8 +8,51 @@
                 <Switch x:Name="MetricDisplay" Toggled="MetricDisplay_Toggled" VerticalOptions="Center" HorizontalOptions="End" />
             </StackLayout>
             <BoxView HorizontalOptions="FillAndExpand" Color="{StaticResource darkBackgroundColor}" HeightRequest="1" Margin="0" />
+
+            <StackLayout Orientation="Horizontal" HorizontalOptions="FillAndExpand" HeightRequest="50">
+                <Label Text="Speed reporting" VerticalOptions="Center" HorizontalOptions="FillAndExpand"/>
+                <Switch x:Name="SpeedReporting" Toggled="SpeedReporting_Toggled" VerticalOptions="Center" HorizontalOptions="End" />
+            </StackLayout>
+            <BoxView HorizontalOptions="FillAndExpand" Color="{StaticResource darkBackgroundColor}" HeightRequest="1" Margin="0" />
+
+            <StackLayout Orientation="Horizontal" HorizontalOptions="FillAndExpand" HeightRequest="50">
+                <Label Text="Speed reporting minimum" VerticalOptions="Center" HorizontalOptions="Fill"/>
+                <Entry x:Name="SpeedReportingMinimum"
+                       Text="3"
+                       VerticalOptions="Center"
+                       HorizontalOptions="EndAndExpand"
+                       TextChanged="SpeedReportingMinimum_TextChanged"
+                       Unfocused="SpeedReportingMinimum_Unfocused"
+                       TextColor="White"
+                       MinimumWidthRequest="50"/>
+            </StackLayout>
+            <BoxView HorizontalOptions="FillAndExpand" Color="{StaticResource darkBackgroundColor}" HeightRequest="1" Margin="0" />
             
-         
+            <StackLayout Orientation="Horizontal" HorizontalOptions="FillAndExpand" HeightRequest="50">
+                <Label Text="Speed reporting baseline timeout" VerticalOptions="Center" HorizontalOptions="Fill"/>
+                <Entry x:Name="SpeedReportingBaselineTimeout"
+                       Text="10"
+                       VerticalOptions="Center"
+                       HorizontalOptions="EndAndExpand"
+                       TextChanged="SpeedReportingBaselineTimeout_TextChanged"
+                       Unfocused="SpeedReportingBaselineTimeout_Unfocused"
+                       TextColor="White"
+                       MinimumWidthRequest="50"/>
+            </StackLayout>
+            <BoxView HorizontalOptions="FillAndExpand" Color="{StaticResource darkBackgroundColor}" HeightRequest="1" Margin="0" />
+
+            <StackLayout Orientation="Horizontal" HorizontalOptions="FillAndExpand" HeightRequest="50">
+                <Label Text="Battery percent reporting" VerticalOptions="Center" HorizontalOptions="FillAndExpand"/>
+                <Switch x:Name="BatteryPercentReporting" Toggled="BatteryPercentReporting_Toggled" VerticalOptions="Center" HorizontalOptions="End" />
+            </StackLayout>
+            <BoxView HorizontalOptions="FillAndExpand" Color="{StaticResource darkBackgroundColor}" HeightRequest="1" Margin="0" />
+
+            <StackLayout Orientation="Horizontal" HorizontalOptions="FillAndExpand" HeightRequest="50">
+                <Label Text="Battery percent from voltage" VerticalOptions="Center" HorizontalOptions="FillAndExpand"/>
+                <Switch x:Name="BatteryPercentInferredBasedOnVoltage" Toggled="BatteryPercentInferredBasedOnVoltage_Toggled" VerticalOptions="Center" HorizontalOptions="End" />
+            </StackLayout>
+            <BoxView HorizontalOptions="FillAndExpand" Color="{StaticResource darkBackgroundColor}" HeightRequest="1" Margin="0" />
+
         </StackLayout>
     </ScrollView>
 </ContentPage>

--- a/OWCE/OWCE/Pages/SettingsPage.xaml.cs
+++ b/OWCE/OWCE/Pages/SettingsPage.xaml.cs
@@ -9,12 +9,25 @@ namespace OWCE.Pages
     {
         private bool _ignoreAlerts = false;
 
+        private int lastValidSpeedReportingMinimum;
+        private int lastValidSpeedReportingBaselineTimeout;
+
         public SettingsPage()
         {
             InitializeComponent();
 
             _ignoreAlerts = true;
             MetricDisplay.IsToggled = App.Current.MetricDisplay;
+            SpeedReporting.IsToggled = App.Current.SpeedReporting;
+            BatteryPercentReporting.IsToggled = App.Current.BatteryPercentReporting;
+            BatteryPercentInferredBasedOnVoltage.IsToggled = App.Current.BatteryPercentInferredBasedOnVoltage;
+
+            lastValidSpeedReportingMinimum = App.Current.SpeedReportingMinimum; // TODO: Hook up settings /w new UI
+            SpeedReportingMinimum.Text = App.Current.SpeedReportingMinimum.ToString();
+
+            lastValidSpeedReportingBaselineTimeout = App.Current.SpeedReportingBaselineTimeout;
+            SpeedReportingBaselineTimeout.Text = App.Current.SpeedReportingBaselineTimeout.ToString();
+
             _ignoreAlerts = false;
             ToolbarItems.Add(new ToolbarItem("Cancel", null, () =>
             {
@@ -22,7 +35,7 @@ namespace OWCE.Pages
             }));
         }
 
-        void MetricDisplay_Toggled(object sender, Xamarin.Forms.ToggledEventArgs e)
+        private void MetricDisplay_Toggled(object sender, Xamarin.Forms.ToggledEventArgs e)
         {
             App.Current.MetricDisplay = e.Value;
             Preferences.Set("metric_display", e.Value);
@@ -33,6 +46,79 @@ namespace OWCE.Pages
             DisplayAlert("Oops", "Please disconnect and reconnect from your board for this change to apply.\n\nThis will be fixed in the future.", "Ok");
         }
 
-       
+        private void SpeedReporting_Toggled(object sender, Xamarin.Forms.ToggledEventArgs e)
+        {
+            App.Current.SpeedReporting = e.Value;
+            Preferences.Set("speed_reporting", e.Value);
+
+            if (_ignoreAlerts)
+                return;
+
+            DisplayAlert("Oops", "Please disconnect and reconnect from your board for this change to apply.\n\nThis will be fixed in the future.", "Ok");
+        }
+
+        private void SpeedReportingMinimum_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (Int32.TryParse(e.NewTextValue, out int newValue) && newValue > 0)
+            {
+                lastValidSpeedReportingMinimum = newValue;
+            }
+        }
+
+        private void SpeedReportingMinimum_Unfocused(object sender, FocusEventArgs e)
+        {
+            var entry = e.VisualElement as Entry;
+            if (entry == null)
+            {
+                throw new InvalidProgramException("Is the callback attached to an element that is not an Entry?");
+            }
+
+            entry.Text = lastValidSpeedReportingMinimum.ToString();
+            App.Current.SpeedReportingMinimum = lastValidSpeedReportingMinimum;
+            Preferences.Set("speedreporting_minimum", lastValidSpeedReportingMinimum);
+        }
+
+        private void SpeedReportingBaselineTimeout_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (Int32.TryParse(e.NewTextValue, out int newValue) && newValue > 0)
+            {
+                lastValidSpeedReportingBaselineTimeout = newValue;
+            }
+        }
+
+        private void SpeedReportingBaselineTimeout_Unfocused(object sender, FocusEventArgs e)
+        {
+            var entry = e.VisualElement as Entry;
+            if (entry == null)
+            {
+                throw new InvalidProgramException("Is the callback attached to an element that is not an Entry?");
+            }
+
+            entry.Text = lastValidSpeedReportingBaselineTimeout.ToString();
+            App.Current.SpeedReportingBaselineTimeout = lastValidSpeedReportingBaselineTimeout;
+            Preferences.Set("speedreporting_baseline_timeout", lastValidSpeedReportingBaselineTimeout);
+        }
+
+        private void BatteryPercentReporting_Toggled(object sender, Xamarin.Forms.ToggledEventArgs e)
+        {
+            App.Current.BatteryPercentReporting = e.Value;
+            Preferences.Set("batterypercent_reporting", e.Value);
+
+            if (_ignoreAlerts)
+                return;
+
+            DisplayAlert("Oops", "Please disconnect and reconnect from your board for this change to apply.\n\nThis will be fixed in the future.", "Ok");
+        }
+
+        private void BatteryPercentInferredBasedOnVoltage_Toggled(object sender, Xamarin.Forms.ToggledEventArgs e)
+        {
+            App.Current.BatteryPercentInferredBasedOnVoltage = e.Value;
+            Preferences.Set("batterypercent_inferred_voltage", e.Value);
+
+            if (_ignoreAlerts)
+                return;
+
+            DisplayAlert("Oops", "Please disconnect and reconnect from your board for this change to apply.\n\nThis will be fixed in the future.", "Ok");
+        }
     }
 }

--- a/OWCE/OWCE/SpeedReporting.cs
+++ b/OWCE/OWCE/SpeedReporting.cs
@@ -1,0 +1,105 @@
+﻿namespace OWCE
+{
+    using OWCE.Converters;
+    using System;
+    using System.Diagnostics;
+    using System.Threading;
+    using Xamarin.Essentials;
+
+    public class SpeedReporting : TTSReporting
+    {
+        private readonly TimeSpan GapTimeIncrementFast = TimeSpan.FromSeconds(2);
+
+        private bool _running = false;
+        private int _lastReportedSpeed = 0;
+        private DateTime _nextHighSpeedTime = DateTime.Now;
+        private DateTime _nextSlowSpeedTime = DateTime.Now;
+
+        private OWBoard _board;
+
+        private int MinSpeed
+        {
+            get
+            {
+                return App.Current.SpeedReportingMinimum > 0 ? App.Current.SpeedReportingMinimum : (App.Current.MetricDisplay ? 5 : 3);
+            }
+        }
+
+        private int TimeInSecsIncrementSlow
+        {
+            get
+            {
+                return App.Current.SpeedReportingBaselineTimeout > 0 ? App.Current.SpeedReportingBaselineTimeout : 10;
+            }
+        }
+
+        public SpeedReporting(OWBoard board, TextToSpeechProvider ttsProvider) : base(ttsProvider)
+        {
+            _board = board;
+            TextToSpeechPriority = 1;
+
+            Debug.WriteLine($"Speed Recording started for {board.BoardType} {board.ID} minspeed {MinSpeed} slowspeed {TimeInSecsIncrementSlow}");
+        }
+
+        public override void Start()
+        {
+            if (_running)
+            {
+                return;
+            }
+
+            _running = true;
+
+            System.Diagnostics.Debug.WriteLine("ACTIVATED Speed Reporting");
+
+            _board.SpeedChanged += Board_SpeedChanged;
+        }
+
+        public override void Stop()
+        {
+            if (!_running)
+            {
+                return;
+            }
+
+            _board.SpeedChanged -= Board_SpeedChanged;
+
+            _running = false;
+
+            System.Diagnostics.Debug.WriteLine("DEACTIVATED Speed Reporting");
+        }
+
+        private void Board_SpeedChanged(object sender, SpeedChangedEventArgs e)
+        {
+            var currentTime = DateTime.Now;
+            int newSpeed = (int)e.speedValue;
+
+            if (newSpeed >= MinSpeed)
+            {
+                if (currentTime > _nextSlowSpeedTime)
+                {
+                    _lastReportedSpeed = newSpeed;
+                    _nextSlowSpeedTime = currentTime + TimeSpan.FromSeconds(TimeInSecsIncrementSlow);
+                    _nextHighSpeedTime = currentTime + GapTimeIncrementFast;
+
+                    string unit = App.Current.MetricDisplay ? "kph" : "mph";
+
+                    System.Diagnostics.Debug.WriteLine($"New slow speed {newSpeed}");
+                    SpeakMessage($"Speed {newSpeed} {unit}");
+                }
+                else if (currentTime > _nextHighSpeedTime)
+                {
+                    if (newSpeed > _lastReportedSpeed)
+                    {
+                        _lastReportedSpeed = newSpeed;
+                        _nextSlowSpeedTime = currentTime + TimeSpan.FromSeconds(TimeInSecsIncrementSlow);
+                        _nextHighSpeedTime = currentTime + GapTimeIncrementFast;
+
+                        System.Diagnostics.Debug.WriteLine($"New fast speed {newSpeed}");
+                        SpeakMessage($"{newSpeed}");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/OWCE/OWCE/Spline/ArrayUtil.cs
+++ b/OWCE/OWCE/Spline/ArrayUtil.cs
@@ -1,0 +1,36 @@
+﻿namespace OWCE.Spline
+{
+	using System;
+	using System.Text;
+
+	/// <summary>
+	/// Utility methods for arrays.
+	/// </summary>
+	public static class ArrayUtil
+	{
+		/// <summary>
+		/// Create a string to display the array values.
+		/// </summary>
+		/// <param name="array">The array</param>
+		/// <param name="format">Optional. A string to use to format each value. Must contain the colon, so something like ':0.000'</param>
+		public static string ToString<T>(T[] array, string format = "")
+		{
+			var s = new StringBuilder();
+			string formatString = "{0" + format + "}";
+
+			for (int i = 0; i < array.Length; i++)
+			{
+				if (i < array.Length - 1)
+				{
+					s.AppendFormat(formatString + ", ", array[i]);
+				}
+				else
+				{
+					s.AppendFormat(formatString, array[i]);
+				}
+			}
+
+			return s.ToString();
+		}
+	}
+}

--- a/OWCE/OWCE/Spline/CubicSpline.cs
+++ b/OWCE/OWCE/Spline/CubicSpline.cs
@@ -1,0 +1,426 @@
+﻿//
+// Author: Ryan Seghers
+//
+// Copyright (C) 2013-2014 Ryan Seghers
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the irrevocable, perpetual, worldwide, and royalty-free
+// rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// display, perform, create derivative works from and/or sell copies of 
+// the Software, both in source and object code form, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+namespace OWCE.Spline
+{
+	using System;
+
+	/// <summary>
+	/// Cubic spline interpolation.
+	/// Call Fit (or use the corrector constructor) to compute spline coefficients, then Eval to evaluate the spline at other X coordinates.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// This is implemented based on the wikipedia article:
+	/// http://en.wikipedia.org/wiki/Spline_interpolation
+	/// I'm not sure I have the right to include a copy of the article so the equation numbers referenced in 
+	/// comments will end up being wrong at some point.
+	/// </para>
+	/// <para>
+	/// This is not optimized, and is not MT safe.
+	/// This can extrapolate off the ends of the splines.
+	/// You must provide points in X sort order.
+	/// </para>
+	/// </remarks>
+	public class CubicSpline
+	{
+		#region Fields
+
+		// N-1 spline coefficients for N points
+		private float[] a;
+		private float[] b;
+
+		// Save the original x and y for Eval
+		private float[] xOrig;
+		private float[] yOrig;
+
+		#endregion
+
+		#region Ctor
+
+		/// <summary>
+		/// Default ctor.
+		/// </summary>
+		public CubicSpline()
+		{
+		}
+
+		/// <summary>
+		/// Construct and call Fit.
+		/// </summary>
+		/// <param name="x">Input. X coordinates to fit.</param>
+		/// <param name="y">Input. Y coordinates to fit.</param>
+		/// <param name="startSlope">Optional slope constraint for the first point. Single.NaN means no constraint.</param>
+		/// <param name="endSlope">Optional slope constraint for the final point. Single.NaN means no constraint.</param>
+		/// <param name="debug">Turn on console output. Default is false.</param>
+		public CubicSpline(float[] x, float[] y, float startSlope = float.NaN, float endSlope = float.NaN, bool debug = false)
+		{
+			Fit(x, y, startSlope, endSlope, debug);
+		}
+
+		#endregion
+
+		#region Private Methods
+
+		/// <summary>
+		/// Throws if Fit has not been called.
+		/// </summary>
+		private void CheckAlreadyFitted()
+		{
+			if (a == null) throw new Exception("Fit must be called before you can evaluate.");
+		}
+
+		private int _lastIndex = 0;
+
+		/// <summary>
+		/// Find where in xOrig the specified x falls, by simultaneous traverse.
+		/// This allows xs to be less than x[0] and/or greater than x[n-1]. So allows extrapolation.
+		/// This keeps state, so requires that x be sorted and xs called in ascending order, and is not multi-thread safe.
+		/// </summary>
+		private int GetNextXIndex(float x)
+		{
+			if (x < xOrig[_lastIndex])
+			{
+				throw new ArgumentException("The X values to evaluate must be sorted.");
+			}
+
+			while ((_lastIndex < xOrig.Length - 2) && (x > xOrig[_lastIndex + 1]))
+			{
+				_lastIndex++;
+			}
+
+			return _lastIndex;
+		}
+
+		/// <summary>
+		/// Evaluate the specified x value using the specified spline.
+		/// </summary>
+		/// <param name="x">The x value.</param>
+		/// <param name="j">Which spline to use.</param>
+		/// <param name="debug">Turn on console output. Default is false.</param>
+		/// <returns>The y value.</returns>
+		private float EvalSpline(float x, int j, bool debug = false)
+		{
+			float dx = xOrig[j + 1] - xOrig[j];
+			float t = (x - xOrig[j]) / dx;
+			float y = (1 - t) * yOrig[j] + t * yOrig[j + 1] + t * (1 - t) * (a[j] * (1 - t) + b[j] * t); // equation 9
+			if (debug) Console.WriteLine("xs = {0}, j = {1}, t = {2}", x, j, t);
+			return y;
+		}
+
+		#endregion
+
+		#region Fit*
+
+		/// <summary>
+		/// Fit x,y and then eval at points xs and return the corresponding y's.
+		/// This does the "natural spline" style for ends.
+		/// This can extrapolate off the ends of the splines.
+		/// You must provide points in X sort order.
+		/// </summary>
+		/// <param name="x">Input. X coordinates to fit.</param>
+		/// <param name="y">Input. Y coordinates to fit.</param>
+		/// <param name="xs">Input. X coordinates to evaluate the fitted curve at.</param>
+		/// <param name="startSlope">Optional slope constraint for the first point. Single.NaN means no constraint.</param>
+		/// <param name="endSlope">Optional slope constraint for the final point. Single.NaN means no constraint.</param>
+		/// <param name="debug">Turn on console output. Default is false.</param>
+		/// <returns>The computed y values for each xs.</returns>
+		public float[] FitAndEval(float[] x, float[] y, float[] xs, float startSlope = float.NaN, float endSlope = float.NaN, bool debug = false)
+		{
+			Fit(x, y, startSlope, endSlope, debug);
+			return Eval(xs, debug);
+		}
+
+		/// <summary>
+		/// Compute spline coefficients for the specified x,y points.
+		/// This does the "natural spline" style for ends.
+		/// This can extrapolate off the ends of the splines.
+		/// You must provide points in X sort order.
+		/// </summary>
+		/// <param name="x">Input. X coordinates to fit.</param>
+		/// <param name="y">Input. Y coordinates to fit.</param>
+		/// <param name="startSlope">Optional slope constraint for the first point. Single.NaN means no constraint.</param>
+		/// <param name="endSlope">Optional slope constraint for the final point. Single.NaN means no constraint.</param>
+		/// <param name="debug">Turn on console output. Default is false.</param>
+		public void Fit(float[] x, float[] y, float startSlope = float.NaN, float endSlope = float.NaN, bool debug = false)
+		{
+			if (Single.IsInfinity(startSlope) || Single.IsInfinity(endSlope))
+			{
+				throw new Exception("startSlope and endSlope cannot be infinity.");
+			}
+
+			// Save x and y for eval
+			this.xOrig = x;
+			this.yOrig = y;
+
+			int n = x.Length;
+			float[] r = new float[n]; // the right hand side numbers: wikipedia page overloads b
+
+			TriDiagonalMatrixF m = new TriDiagonalMatrixF(n);
+			float dx1, dx2, dy1, dy2;
+
+			// First row is different (equation 16 from the article)
+			if (float.IsNaN(startSlope))
+			{
+				dx1 = x[1] - x[0];
+				m.C[0] = 1.0f / dx1;
+				m.B[0] = 2.0f * m.C[0];
+				r[0] = 3 * (y[1] - y[0]) / (dx1 * dx1);
+			}
+			else
+			{
+				m.B[0] = 1;
+				r[0] = startSlope;
+			}
+
+			// Body rows (equation 15 from the article)
+			for (int i = 1; i < n - 1; i++)
+			{
+				dx1 = x[i] - x[i - 1];
+				dx2 = x[i + 1] - x[i];
+
+				m.A[i] = 1.0f / dx1;
+				m.C[i] = 1.0f / dx2;
+				m.B[i] = 2.0f * (m.A[i] + m.C[i]);
+
+				dy1 = y[i] - y[i - 1];
+				dy2 = y[i + 1] - y[i];
+				r[i] = 3 * (dy1 / (dx1 * dx1) + dy2 / (dx2 * dx2));
+			}
+
+			// Last row also different (equation 17 from the article)
+			if (float.IsNaN(endSlope))
+			{
+				dx1 = x[n - 1] - x[n - 2];
+				dy1 = y[n - 1] - y[n - 2];
+				m.A[n - 1] = 1.0f / dx1;
+				m.B[n - 1] = 2.0f * m.A[n - 1];
+				r[n - 1] = 3 * (dy1 / (dx1 * dx1));
+			}
+			else
+			{
+				m.B[n - 1] = 1;
+				r[n - 1] = endSlope;
+			}
+
+			if (debug) Console.WriteLine("Tri-diagonal matrix:\n{0}", m.ToDisplayString(":0.0000", "  "));
+			if (debug) Console.WriteLine("r: {0}", ArrayUtil.ToString<float>(r));
+
+			// k is the solution to the matrix
+			float[] k = m.Solve(r);
+			if (debug) Console.WriteLine("k = {0}", ArrayUtil.ToString<float>(k));
+
+			// a and b are each spline's coefficients
+			this.a = new float[n - 1];
+			this.b = new float[n - 1];
+
+			for (int i = 1; i < n; i++)
+			{
+				dx1 = x[i] - x[i - 1];
+				dy1 = y[i] - y[i - 1];
+				a[i - 1] = k[i - 1] * dx1 - dy1; // equation 10 from the article
+				b[i - 1] = -k[i] * dx1 + dy1; // equation 11 from the article
+			}
+
+			if (debug) Console.WriteLine("a: {0}", ArrayUtil.ToString<float>(a));
+			if (debug) Console.WriteLine("b: {0}", ArrayUtil.ToString<float>(b));
+		}
+
+		#endregion
+
+		#region Eval*
+
+		/// <summary>
+		/// Evaluate the spline at the specified x coordinates.
+		/// This can extrapolate off the ends of the splines.
+		/// You must provide X's in ascending order.
+		/// The spline must already be computed before calling this, meaning you must have already called Fit() or FitAndEval().
+		/// </summary>
+		/// <param name="x">Input. X coordinates to evaluate the fitted curve at.</param>
+		/// <param name="debug">Turn on console output. Default is false.</param>
+		/// <returns>The computed y values for each x.</returns>
+		public float[] Eval(float[] x, bool debug = false)
+		{
+			CheckAlreadyFitted();
+
+			int n = x.Length;
+			float[] y = new float[n];
+			_lastIndex = 0; // Reset simultaneous traversal in case there are multiple calls
+
+			for (int i = 0; i < n; i++)
+			{
+				// Find which spline can be used to compute this x (by simultaneous traverse)
+				int j = GetNextXIndex(x[i]);
+
+				// Evaluate using j'th spline
+				y[i] = EvalSpline(x[i], j, debug);
+			}
+
+			return y;
+		}
+
+		/// <summary>
+		/// Evaluate (compute) the slope of the spline at the specified x coordinates.
+		/// This can extrapolate off the ends of the splines.
+		/// You must provide X's in ascending order.
+		/// The spline must already be computed before calling this, meaning you must have already called Fit() or FitAndEval().
+		/// </summary>
+		/// <param name="x">Input. X coordinates to evaluate the fitted curve at.</param>
+		/// <param name="debug">Turn on console output. Default is false.</param>
+		/// <returns>The computed y values for each x.</returns>
+		public float[] EvalSlope(float[] x, bool debug = false)
+		{
+			CheckAlreadyFitted();
+
+			int n = x.Length;
+			float[] qPrime = new float[n];
+			_lastIndex = 0; // Reset simultaneous traversal in case there are multiple calls
+
+			for (int i = 0; i < n; i++)
+			{
+				// Find which spline can be used to compute this x (by simultaneous traverse)
+				int j = GetNextXIndex(x[i]);
+
+				// Evaluate using j'th spline
+				float dx = xOrig[j + 1] - xOrig[j];
+				float dy = yOrig[j + 1] - yOrig[j];
+				float t = (x[i] - xOrig[j]) / dx;
+
+				// From equation 5 we could also compute q' (qp) which is the slope at this x
+				qPrime[i] = dy / dx
+					+ (1 - 2 * t) * (a[j] * (1 - t) + b[j] * t) / dx
+					+ t * (1 - t) * (b[j] - a[j]) / dx;
+
+				if (debug) Console.WriteLine("[{0}]: xs = {1}, j = {2}, t = {3}", i, x[i], j, t);
+			}
+
+			return qPrime;
+		}
+
+		#endregion
+
+		#region Static Methods
+
+		/// <summary>
+		/// Static all-in-one method to fit the splines and evaluate at X coordinates.
+		/// </summary>
+		/// <param name="x">Input. X coordinates to fit.</param>
+		/// <param name="y">Input. Y coordinates to fit.</param>
+		/// <param name="xs">Input. X coordinates to evaluate the fitted curve at.</param>
+		/// <param name="startSlope">Optional slope constraint for the first point. Single.NaN means no constraint.</param>
+		/// <param name="endSlope">Optional slope constraint for the final point. Single.NaN means no constraint.</param>
+		/// <param name="debug">Turn on console output. Default is false.</param>
+		/// <returns>The computed y values for each xs.</returns>
+		public static float[] Compute(float[] x, float[] y, float[] xs, float startSlope = float.NaN, float endSlope = float.NaN, bool debug = false)
+		{
+			CubicSpline spline = new CubicSpline();
+			return spline.FitAndEval(x, y, xs, startSlope, endSlope, debug);
+		}
+
+        /// <summary>
+        /// Fit the input x,y points using the parametric approach, so that y does not have to be an explicit
+        /// function of x, meaning there does not need to be a single value of y for each x.
+        /// </summary>
+        /// <param name="x">Input x coordinates.</param>
+        /// <param name="y">Input y coordinates.</param>
+        /// <param name="nOutputPoints">How many output points to create.</param>
+        /// <param name="xs">Output (interpolated) x values.</param>
+        /// <param name="ys">Output (interpolated) y values.</param>
+        /// <param name="firstDx">Optionally specifies the first point's slope in combination with firstDy. Together they
+        /// are a vector describing the direction of the parametric spline of the starting point. The vector does
+        /// not need to be normalized. If either is NaN then neither is used.</param>
+        /// <param name="firstDy">See description of dx0.</param>
+        /// <param name="lastDx">Optionally specifies the last point's slope in combination with lastDy. Together they
+        /// are a vector describing the direction of the parametric spline of the last point. The vector does
+        /// not need to be normalized. If either is NaN then neither is used.</param>
+        /// <param name="lastDy">See description of dxN.</param>
+        public static void FitParametric(float[] x, float[] y, int nOutputPoints, out float[] xs, out float[] ys,
+            float firstDx = Single.NaN, float firstDy = Single.NaN, float lastDx = Single.NaN, float lastDy = Single.NaN)
+		{
+			// Compute distances
+			int n = x.Length;
+			float[] dists = new float[n]; // cumulative distance
+			dists[0] = 0;
+			float totalDist = 0;
+
+			for (int i = 1; i < n; i++)
+			{
+				float dx = x[i] - x[i - 1];
+				float dy = y[i] - y[i - 1];
+				float dist = (float)Math.Sqrt(dx * dx + dy * dy);
+				totalDist += dist;
+				dists[i] = totalDist;
+			}
+
+			// Create 'times' to interpolate to
+			float dt = totalDist / (nOutputPoints - 1);
+			float[] times = new float[nOutputPoints];
+			times[0] = 0;
+
+			for (int i = 1; i < nOutputPoints; i++)
+			{
+				times[i] = times[i - 1] + dt;
+			}
+
+            // Normalize the slopes, if specified
+            NormalizeVector(ref firstDx, ref firstDy);
+            NormalizeVector(ref lastDx, ref lastDy);
+
+			// Spline fit both x and y to times
+			CubicSpline xSpline = new CubicSpline();
+			xs = xSpline.FitAndEval(dists, x, times, firstDx / dt, lastDx / dt);
+
+			CubicSpline ySpline = new CubicSpline();
+			ys = ySpline.FitAndEval(dists, y, times, firstDy / dt, lastDy / dt);
+		}
+
+        private static void NormalizeVector(ref float dx, ref float dy)
+        {
+            if (!Single.IsNaN(dx) && !Single.IsNaN(dy))
+            {
+                float d = (float)Math.Sqrt(dx * dx + dy * dy);
+
+                if (d > Single.Epsilon) // probably not conservative enough, but catches the (0,0) case at least
+                {
+                    dx = dx / d;
+                    dy = dy / d;
+                }
+                else
+                {
+                    throw new ArgumentException("The input vector is too small to be normalized.");
+                }
+            }
+            else
+            {
+                // In case one is NaN and not the other
+                dx = dy = Single.NaN;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/OWCE/OWCE/Spline/TriDiagonalMatrix.cs
+++ b/OWCE/OWCE/Spline/TriDiagonalMatrix.cs
@@ -1,0 +1,215 @@
+﻿//
+// Author: Ryan Seghers
+//
+// Copyright (C) 2013-2014 Ryan Seghers
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the irrevocable, perpetual, worldwide, and royalty-free
+// rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// display, perform, create derivative works from and/or sell copies of 
+// the Software, both in source and object code form, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+namespace OWCE.Spline
+{
+	using System;
+	using System.Diagnostics;
+	using System.Text;
+
+	/// <summary>
+	/// A tri-diagonal matrix has non-zero entries only on the main diagonal, the diagonal above the main (super), and the
+	/// diagonal below the main (sub).
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// This is based on the wikipedia article: http://en.wikipedia.org/wiki/Tridiagonal_matrix_algorithm
+	/// </para>
+	/// <para>
+	/// The entries in the matrix on a particular row are A[i], B[i], and C[i] where i is the row index.
+	/// B is the main diagonal, and so for an NxN matrix B is length N and all elements are used.
+	/// So for row 0, the first two values are B[0] and C[0].
+	/// And for row N-1, the last two values are A[N-1] and B[N-1].
+	/// That means that A[0] is not actually on the matrix and is therefore never used, and same with C[N-1].
+	/// </para>
+	/// </remarks>
+	public class TriDiagonalMatrixF
+	{
+		/// <summary>
+		/// The values for the sub-diagonal. A[0] is never used.
+		/// </summary>
+		public float[] A;
+
+		/// <summary>
+		/// The values for the main diagonal.
+		/// </summary>
+		public float[] B;
+
+		/// <summary>
+		/// The values for the super-diagonal. C[C.Length-1] is never used.
+		/// </summary>
+		public float[] C;
+
+		/// <summary>
+		/// The width and height of this matrix.
+		/// </summary>
+		public int N
+		{
+			get { return (A != null ? A.Length : 0); }
+		}
+
+		/// <summary>
+		/// Indexer. Setter throws an exception if you try to set any not on the super, main, or sub diagonals.
+		/// </summary>
+		public float this[int row, int col]
+		{
+			get
+			{
+				int di = row - col;
+
+				if (di == 0)
+				{
+					return B[row];
+				}
+				else if (di == -1)
+				{
+					Debug.Assert(row < N - 1);
+					return C[row];
+				}
+				else if (di == 1)
+				{
+					Debug.Assert(row > 0);
+					return A[row];
+				}
+				else return 0;
+			}
+			set
+			{
+				int di = row - col;
+
+				if (di == 0)
+				{
+					B[row] = value;
+				}
+				else if (di == -1)
+				{
+					Debug.Assert(row < N - 1);
+					C[row] = value;
+				}
+				else if (di == 1)
+				{
+					Debug.Assert(row > 0);
+					A[row] = value;
+				}
+				else
+				{
+					throw new ArgumentException("Only the main, super, and sub diagonals can be set.");
+				}
+			}
+		}
+
+		/// <summary>
+		/// Construct an NxN matrix.
+		/// </summary>
+		public TriDiagonalMatrixF(int n)
+		{
+			this.A = new float[n];
+			this.B = new float[n];
+			this.C = new float[n];
+		}
+
+		/// <summary>
+		/// Produce a string representation of the contents of this matrix.
+		/// </summary>
+		/// <param name="fmt">Optional. For String.Format. Must include the colon. Examples are ':0.000' and ',5:0.00' </param>
+		/// <param name="prefix">Optional. Per-line indentation prefix.</param>
+		public string ToDisplayString(string fmt = "", string prefix = "")
+		{
+			if (this.N > 0)
+			{
+				var s = new StringBuilder();
+				string formatString = "{0" + fmt + "}";
+
+				for (int r = 0; r < N; r++)
+				{
+					s.Append(prefix);
+
+					for (int c = 0; c < N; c++)
+					{
+						s.AppendFormat(formatString, this[r, c]);
+						if (c < N - 1) s.Append(", ");
+					}
+
+					s.AppendLine();
+				}
+
+				return s.ToString();
+			}
+			else
+			{
+				return prefix + "0x0 Matrix";
+			}
+		}
+
+		/// <summary>
+		/// Solve the system of equations this*x=d given the specified d.
+		/// </summary>
+		/// <remarks>
+		/// Uses the Thomas algorithm described in the wikipedia article: http://en.wikipedia.org/wiki/Tridiagonal_matrix_algorithm
+		/// Not optimized. Not destructive.
+		/// </remarks>
+		/// <param name="d">Right side of the equation.</param>
+		public float[] Solve(float[] d)
+		{
+			int n = this.N;
+
+			if (d.Length != n)
+			{
+				throw new ArgumentException("The input d is not the same size as this matrix.");
+			}
+
+			// cPrime
+			float[] cPrime = new float[n];
+			cPrime[0] = C[0] / B[0];
+
+			for (int i = 1; i < n; i++)
+			{
+				cPrime[i] = C[i] / (B[i] - cPrime[i-1] * A[i]);
+			}
+
+			// dPrime
+			float[] dPrime = new float[n];
+			dPrime[0] = d[0] / B[0];
+
+			for (int i = 1; i < n; i++)
+			{
+				dPrime[i] = (d[i] - dPrime[i-1]*A[i]) / (B[i] - cPrime[i - 1] * A[i]);
+			}
+
+			// Back substitution
+			float[] x = new float[n];
+			x[n - 1] = dPrime[n - 1];
+
+			for (int i = n-2; i >= 0; i--)
+			{
+				x[i] = dPrime[i] - cPrime[i] * x[i + 1];
+			}
+
+			return x;
+		}
+	}
+}

--- a/OWCE/OWCE/TTSReporting.cs
+++ b/OWCE/OWCE/TTSReporting.cs
@@ -1,0 +1,35 @@
+﻿namespace OWCE
+{
+    using System;
+    using Xamarin.Essentials;
+
+    public abstract class TTSReporting
+    {
+        protected int TextToSpeechPriority = 0; // Higher or equal priority overrides currently active TTS
+
+        private TextToSpeechProvider _textToSpeechProvider = null;
+
+        public TTSReporting(TextToSpeechProvider ttsProvider)
+        {
+            _textToSpeechProvider = ttsProvider;
+        }
+
+        public abstract void Start();
+        public abstract void Stop();
+
+        public void SpeakMessage(string text)
+        {
+            SpeakMessage(text, null);
+        }
+
+        public void SpeakMessage(string text, SpeechOptions speechOptions)
+        {
+            if (_textToSpeechProvider == null)
+            {
+                throw new NullReferenceException("Class did not call base constructor");
+            }
+
+            _textToSpeechProvider.SpeakMessage(text, speechOptions, TextToSpeechPriority);
+        }
+    }
+}

--- a/OWCE/OWCE/TextToSpeechProvider.cs
+++ b/OWCE/OWCE/TextToSpeechProvider.cs
@@ -1,0 +1,60 @@
+﻿namespace OWCE
+{
+    using System;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xamarin.Essentials;
+
+    /// <summary>
+    /// TTS Messages go through this class to decide whether based on message priority the message cancels & overrides another message being spoken.
+    /// </summary>
+    public class TextToSpeechProvider
+    {
+        private CancellationTokenSource _speedReportingCts;
+        private Task _speechTask = null;
+        private int _currentSpeechTaskPriority = -1;
+        private object _ttsLock = new object();
+
+        public void SpeakMessage(string text, int priority = 0)
+        {
+            SpeakMessage(text, null, priority);
+        }
+
+        public void SpeakMessage(string text, SpeechOptions speechOptions, int priority = 0)
+        {
+            lock (_ttsLock)
+            {
+                if (!CanSpeak(priority))
+                {
+                    return;
+                }
+
+                CancelSpeech();
+                _speedReportingCts = new CancellationTokenSource();
+                _currentSpeechTaskPriority = priority;
+                _speechTask = TextToSpeech.SpeakAsync(text, speechOptions, _speedReportingCts.Token);
+            }
+        }
+
+        // Cancel speech if a cancellation token exists & hasn't been already requested.
+        private void CancelSpeech()
+        {
+            if (_speedReportingCts?.IsCancellationRequested ?? true)
+            {
+                return;
+            }
+
+            _speedReportingCts.Cancel();
+        }
+
+        private bool CanSpeak(int priority)
+        {
+            return _speechTask == null
+                || _speechTask.IsCompleted
+                || _speechTask.IsFaulted
+                || _speechTask.IsCanceled
+                || priority >= _currentSpeechTaskPriority;
+        }
+    }
+}

--- a/OWCE/OWCE/Views/SpeedRangeDistanceView.xaml
+++ b/OWCE/OWCE/Views/SpeedRangeDistanceView.xaml
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <ContentView xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" xmlns:yummy="clr-namespace:Xamarin.Forms.PancakeView;assembly=Xamarin.Forms.PancakeView" xmlns:views="clr-namespace:OWCE.Views" xmlns:converters="clr-namespace:OWCE.Converters" x:Class="OWCE.Views.SpeedRangeDistanceView">
     <ContentView.Resources>
-        <converters:RpmToSpeedConverter x:Key="rpmToSpeedConverter" />
         <converters:DistanceConverter x:Key="distanceConverter" />
     </ContentView.Resources>
     <yummy:PancakeView BackgroundColor="#FFFF00"  Style="{StaticResource BoardDetailBlockBaseStyle}">
@@ -41,7 +40,7 @@
                     </Label>
 
                     <Label Text="SPEED" FontFamily="SairaExtraCondensed-Bold" TextColor="Black"   CharacterSpacing="0.26" FontSize="16" Margin="20,6,0,0" />
-                    <Label Text="{Binding RPM, Converter={StaticResource rpmToSpeedConverter}, ConverterParameter={Binding WheelCircumference}, StringFormat='{0:F0}'}"  TextColor="Black"  FontFamily="SairaExtraCondensed-Black" FontSize="125" HorizontalOptions="Center" VerticalOptions="Start"  />
+                    <Label Text="{Binding Speed, StringFormat='{0:F0}'}"  TextColor="Black"  FontFamily="SairaExtraCondensed-Black" FontSize="125" HorizontalOptions="Center" VerticalOptions="Start"  />
 
                     <Label TextColor="Black" FontFamily="SairaExtraCondensed-Black" FontSize="30" CharacterSpacing="0.97" HorizontalOptions="Center" VerticalOptions="End" VerticalTextAlignment="End">
                         <Label.Triggers>

--- a/OWCE/OWCE/Views/SpeedRangeDistanceView.xaml.cs
+++ b/OWCE/OWCE/Views/SpeedRangeDistanceView.xaml.cs
@@ -22,20 +22,19 @@ namespace OWCE.Views
             }
         }
 
-        public static readonly BindableProperty WheelCircumferenceProperty = BindableProperty.Create(
-            "WheelCircumference",
-            typeof(float),
+        public static readonly BindableProperty SpeedProperty = BindableProperty.Create(
+            "Speed",
+            typeof(int),
             typeof(SpeedRangeDistanceView));
 
-        public float WheelCircumference
+        public int Speed
         {
-            get { return (float)GetValue(WheelCircumferenceProperty); }
+            get { return (int)GetValue(SpeedProperty); }
             set
             {
-                SetValue(WheelCircumferenceProperty, value);
+                SetValue(SpeedProperty, value);
             }
         }
-
 
         public static readonly BindableProperty LifetimeOdometerProperty = BindableProperty.Create(
             "LifetimeOdometer",

--- a/OWCE/OWCE/VoltageAggregator.cs
+++ b/OWCE/OWCE/VoltageAggregator.cs
@@ -1,0 +1,98 @@
+﻿namespace OWCE
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+
+    public class VoltageAggregator
+    {
+        private readonly TimeSpan TrimPeriod = TimeSpan.FromSeconds(60);
+
+        private LinkedList<VoltageEntry> _contiguousList = new LinkedList<VoltageEntry>();
+        private SortedList<float, VoltageEntry> _sortedList = new SortedList<float, VoltageEntry>(4096, new DuplicateKeyComparer<float>());
+        private object entryLock = new object();
+
+        public VoltageAggregator()
+        {
+        }
+
+        public void AppendVoltageEntry(float voltage)
+        {
+            lock (entryLock)
+            {
+                var currentTime = DateTime.Now;
+                var trimTime = currentTime - TrimPeriod;
+                var newEntry = new VoltageEntry() { Voltage = voltage, Time = currentTime };
+
+                _contiguousList.AddLast(newEntry);
+                _sortedList.Add(voltage, newEntry);
+
+                int countTrimmed = 0;
+                while (_contiguousList.Count != 0 && _contiguousList.First.Value.Time < trimTime)
+                {
+                    var entryBeingRemoved = _contiguousList.First.Value;
+                    _sortedList.Remove(entryBeingRemoved.Voltage);
+                    _contiguousList.RemoveFirst();
+                    ++countTrimmed;
+                }
+
+                Debug.WriteLine($"AppendVoltageEntry trimmed {countTrimmed} entries.");
+            }
+        }
+
+        public float GetMedianVoltage()
+        {
+            lock (entryLock)
+            {
+                int count = _sortedList.Count;
+                if (count == 0)
+                {
+                    return 0;
+                }
+
+                int i = count / 2;
+                if (count % 2 == 0)
+                {
+                    var voltages = _sortedList.Keys;
+                    return (voltages[i-1] + voltages[i]) * 0.5f;
+                }
+                else
+                {
+                    return _sortedList.Keys[i];
+                }
+            }
+        }
+
+        private class VoltageEntry
+        {
+            public float Voltage { get; set; }
+            public DateTime Time { get; set; }
+        }
+
+        /// <summary>
+        /// Comparer for comparing two keys, handling equality as beeing greater
+        /// Use this Comparer e.g. with SortedLists or SortedDictionaries, that don't allow duplicate keys
+        /// </summary>
+        /// <typeparam name="TKey"></typeparam>
+        private class DuplicateKeyComparer<TKey> : IComparer<TKey> where TKey : IComparable
+        {
+            #region IComparer<TKey> Members
+
+            public int Compare(TKey x, TKey y)
+            {
+                int result = x.CompareTo(y);
+
+                if (result == 0)
+                {
+                    return 1;   // Handle equality as beeing greater
+                }
+                else
+                {
+                    return result;
+                }
+            }
+
+            #endregion
+        }
+    }
+}


### PR DESCRIPTION
Features:
- 'Speed Alerts' UI toggle has been added, which calls out speeds via text to speech.
	- While no UI exists to configure speed alerting, default values are min speed 10mph/15kph with a reset timer of 15 sec. This has a good initial balance to avoid being an annoyance at low speed. Hidden old SettingsPage has the configurable fields.
- 'Battery Updates' UI toggle has been added, which calls out battery at every 10% via text to speech.
- 'Show battery % based on voltage' UI toggle has been added, which switches the battery percentage used for UI & Battery Updates to use voltage-mapped battery percentage.
	- Median value for voltage over last 60 sec is used to determine the mapping to battery percentage, which means values will skew significantly in the early period after connecting to the OW, since nominal voltage differs ~4V depending on power draw.
	- Voltage-battery% mapping is done by interpolating discrete values from CBXR battery chart. Interpolation is done using cubic splines with 1000 steps over the range.
	

Additional changes & details
- Speed UI now reflects wheel circumference of the device
- Debug mocking has been added for testing battery percentage mapping & reporting. Look up '_enableMockBatteryPercentage' in OWBoard.cs
