### PR TITLE
Watch Performance fix: Unsubscribe from messages when watch app is not visible

### DIFF
--- a/OWCE/OWCE.WatchOS/OWCE.WatchOS.WatchOSExtension/InterfaceController.cs
+++ b/OWCE/OWCE.WatchOS/OWCE.WatchOS.WatchOSExtension/InterfaceController.cs
@@ -17,21 +17,21 @@ namespace OWCE.WatchOS.WatchOSExtension
             // Note: this .ctor should not contain any initialization logic.
         }
 
-        public override void Awake(NSObject context)
-        {
-            base.Awake(context);
+        //public override void Awake(NSObject context)
+        //{
+        //    base.Awake(context);
 
-            // Configure interface objects here.
-            Console.WriteLine("{0} awake with context", this);
-
-            // Register for notifications, eg when the phone updates new
-            // values for speed, distance etc
-            WCSessionManager.SharedManager.MessageReceived += DidReceiveMessage;
-        }
+        //    // Configure interface objects here.
+        //    // Console.WriteLine("{0} awake with context", this);
+        //}
 
         public override void WillActivate()
         {
             // This method is called when the watch view controller is about to be visible to the user.
+
+            // Register for messages, eg when the phone updates new
+            // values for speed, distance etc
+            WCSessionManager.SharedManager.MessageReceived += DidReceiveMessage;
 
             // Check whether session is active
             if (!WCSessionManager.SharedManager.IsReachable())
@@ -61,6 +61,10 @@ namespace OWCE.WatchOS.WatchOSExtension
         {
             // This method is called when the watch view controller is no longer visible to the user.
             source.Cancel();
+
+            // Unsubscribe to messages, so that we don't inadvertently act on
+            // phone messages while the watch app is inactive.
+            WCSessionManager.SharedManager.MessageReceived -= DidReceiveMessage;
         }
 
         // Called when the phone has new values to update on the watch display.


### PR DESCRIPTION
Previously, the watch app subscribed to messages when `Awake()` was called (ie when the watch's view was instantiated, which happens once at the beginning), and never un-subscribed, and I suspect that led to the watch app always attempting to respond to the phone messages and updating the UI even though the app is not visible. This probably contributes to battery drain. 

The change here is to unsubscribe to messages when the app `DidDeactivate()` and re-subscribe only when the app `WillActivate()`.

I've tested this on a short ride, and the app works for me with this change. I haven't been able to verify any improvements on battery drain yet, but my sense is that this change is at the very least harmless and good to have.