### PR TITLE
Watch sync improvements

### DIFF
--- a/OWCE/OWCE.Android/DependencyImplementations/Watch.cs
+++ b/OWCE/OWCE.Android/DependencyImplementations/Watch.cs
@@ -1,4 +1,5 @@
-﻿using OWCE.DependencyInterfaces;
+﻿using System.Collections.Generic;
+using OWCE.DependencyInterfaces;
 using Xamarin.Forms;
 
 [assembly: Dependency(typeof(OWCE.Droid.DependencyImplementations.Watch))]
@@ -7,22 +8,7 @@ namespace OWCE.Droid.DependencyImplementations
 {
     public class Watch : IWatch
     {
-        public void UpdateBatteryPercent(int percent)
-        {
-            // Implement when we have Android Watch support
-        }
-
-        public void UpdateDistance(string distanceString)
-        {
-            // Implement when we have Android Watch support
-        }
-
-        public void UpdateSpeed(int speed)
-        {
-            // Implement when we have Android Watch support
-        }
-
-        public void UpdateVoltage(float voltage)
+        public void SendWatchMessages(Dictionary<string, object> messages)
         {
             // Implement when we have Android Watch support
         }

--- a/OWCE/OWCE.iOS/DependencyImplementations/Watch.cs
+++ b/OWCE/OWCE.iOS/DependencyImplementations/Watch.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using OWCE.Converters;
 using OWCE.DependencyInterfaces;
+using OWCE.PropertyChangeHandlers;
 using WatchConnectivity;
 using Xamarin.Forms;
 
@@ -15,34 +16,9 @@ namespace OWCE.iOS.DependencyImplementations
     {
         private OWBoard _board;
 
-        public void BoardConnected()
+        public void SendWatchMessages(Dictionary<string, object> messages)
         {
-            WCSessionManager.SharedManager.SendMessage(new Dictionary<string, object>() {
-                { "MessagePhone", "Connected" } });
-        }
-
-        void IWatch.UpdateBatteryPercent(int percent)
-        {
-            WCSessionManager.SharedManager.SendMessage(new Dictionary<string, object>() {
-                { "BatteryPercent", percent } });
-        }
-
-        void IWatch.UpdateDistance(string distanceString)
-        {
-            WCSessionManager.SharedManager.SendMessage(new Dictionary<string, object>() {
-                { "Distance", distanceString } });
-        }
-
-        void IWatch.UpdateSpeed(int speed)
-        {
-            WCSessionManager.SharedManager.SendMessage(new Dictionary<string, object>() {
-                { "Speed", speed} });
-        }
-
-        void IWatch.UpdateVoltage(float voltage)
-        {
-            WCSessionManager.SharedManager.SendMessage(new Dictionary<string, object>() {
-                { "Voltage", voltage} });
+            WCSessionManager.SharedManager.SendMessage(messages);
         }
 
         void IWatch.ListenForWatchMessages(OWBoard board)
@@ -58,41 +34,7 @@ namespace OWCE.iOS.DependencyImplementations
 
         public void DidReceiveMessage(WCSession session, Dictionary<string, object> message)
         {
-            if (message.ContainsKey("WatchAppAwake"))
-            {
-                if (_board == null)
-                {
-                    Console.WriteLine("Board not initialized yet. Returning");
-                    return;
-                }
-                // Watch just woke up -- send all current data to bring
-                // the watch up to speed
-                SendAllBoardData(_board);
-            }
-        }
-
-        private void SendAllBoardData(OWBoard board)
-        {
-            try
-            {
-                int rpm = board.RPM;
-                int speedMph = (int)RpmToSpeedConverter.ConvertFromRpm(rpm);
-                ushort tripOdometer = board.TripOdometer;
-                string distanceString = RotationsToDistanceConverter.ConvertRotationsToDistance(tripOdometer);
-
-                WCSessionManager.SharedManager.SendMessage(new Dictionary<string, object>() {
-                        { "BatteryPercent", board.BatteryPercent },
-                        { "Speed", speedMph},
-                        { "Voltage", board.BatteryVoltage},
-                        { "SpeedUnitsLabel", App.Current.MetricDisplay ? "km/h" : "mph"},
-                        { "Distance", distanceString}
-                    });
-
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Exception Processing Message: {ex.Message}");
-            }
+            WatchSyncEventHandler.HandleWatchMessage(message, _board);
         }
     }
 }

--- a/OWCE/OWCE.iOS/DependencyImplementations/Watch.cs
+++ b/OWCE/OWCE.iOS/DependencyImplementations/Watch.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using OWCE.Converters;
+﻿using System.Collections.Generic;
 using OWCE.DependencyInterfaces;
 using OWCE.PropertyChangeHandlers;
 using WatchConnectivity;

--- a/OWCE/OWCE/DependencyInterfaces/iWatch.cs
+++ b/OWCE/OWCE/DependencyInterfaces/iWatch.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+
 namespace OWCE.DependencyInterfaces
 {
     // Handles communication with the watch.
@@ -6,10 +8,7 @@ namespace OWCE.DependencyInterfaces
     // this interface via DependencyService
     public interface IWatch
     {
-        void UpdateBatteryPercent(int percent);
-        void UpdateSpeed(int speed);
-        void UpdateVoltage(float voltage);
-        void UpdateDistance(string distanceString);
+        void SendWatchMessages(Dictionary<string, object> messages);
         void ListenForWatchMessages(OWBoard board);
         void StopListeningForWatchMessages();
     }

--- a/OWCE/OWCE/PropertyChangeHandlers/WatchSyncEventHandler.cs
+++ b/OWCE/OWCE/PropertyChangeHandlers/WatchSyncEventHandler.cs
@@ -9,41 +9,66 @@ namespace OWCE.PropertyChangeHandlers
 {
     public class WatchSyncEventHandler
     {
-        private static HashSet<String> PropertiesToWatch = new HashSet<string> { "BatteryVoltage", "RPM", "TripOdometer" };
+        private static readonly HashSet<String> PropertiesToWatch = new HashSet<string> { "BatteryPercent", "BatteryVoltage", "RPM", "TripOdometer" };
 
+        public static readonly WatchSyncEventHandler Instance = new WatchSyncEventHandler();
+
+        private Dictionary<string, object> watchUpdates = new Dictionary<string, object>();
+
+        // Updates the watch with the given property
+        // - propertyName: null if updating all properties
+        private void UpdateProperty(string propertyName, OWBoard board)
+        {
+            if (propertyName == null || propertyName.Equals("BatteryVoltage"))
+            {
+                float voltage = board.BatteryVoltage;
+                watchUpdates.Add("Voltage", voltage);
+
+                // For Quart, should add battery percent here
+            }
+            if (propertyName == null || propertyName.Equals("RPM"))
+            {
+                int rpm = board.RPM;
+                int speed = (int)RpmToSpeedConverter.ConvertFromRpm(rpm);
+                watchUpdates.Add("Speed", speed);
+            }
+            if (propertyName == null || propertyName.Equals("BatteryPercent"))
+            {
+                int batteryPercent = board.BatteryPercent;
+                watchUpdates.Add("BatteryPercent", batteryPercent);
+            }
+            if (propertyName == null || propertyName.Equals("TripOdometer"))
+            {
+                ushort tripOdometer = board.TripOdometer;
+                string tripDescription = RotationsToDistanceConverter.ConvertRotationsToDistance(tripOdometer);
+                watchUpdates.Add("Distance", tripDescription);
+            }
+            if (propertyName == null)
+            {
+                watchUpdates.Add("SpeedUnitsLabel", App.Current.MetricDisplay ? "km/h" : "mph");
+            }
+            // TODO: Here we can implement delayed send
+            FlushMessages();
+        }
+
+        private void FlushMessages()
+        {
+            var updates = watchUpdates;
+            watchUpdates = new Dictionary<string, object>();
+
+            IWatch watchService = DependencyService.Get<IWatch>();
+            watchService.SendWatchMessages(updates);
+        }
+
+        // Invoked when the OWBoard has properties changed (eg Speed, Voltage) that we need
+        // to update the watch on
         public static void HandlePropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             try
             {
                 if (!PropertiesToWatch.Contains(e.PropertyName)) { return; }
 
-                IWatch watchService = DependencyService.Get<IWatch>();
-                if (e.PropertyName.Equals("BatteryVoltage"))
-                {
-                    float voltage = (sender as OWBoard).BatteryVoltage;
-                    watchService.UpdateVoltage(voltage);
-
-                    // For Quart
-                    //double pct = 99.9 / (0.8 + Math.Pow(1.28, 54 - voltage)) - 9;
-                    //watchService.UpdateBatteryPercent((int)pct);
-                }
-                if (e.PropertyName.Equals("RPM"))
-                {
-                    int rpm = (sender as OWBoard).RPM;
-                    int speedMph = (int)RpmToSpeedConverter.ConvertFromRpm(rpm);
-                    watchService.UpdateSpeed(speedMph);
-                }
-                if (e.PropertyName.Equals("BatteryPercent"))
-                {
-                    int batteryPercent = (sender as OWBoard).BatteryPercent;
-                    watchService.UpdateBatteryPercent(batteryPercent);
-                }
-                if (e.PropertyName.Equals("TripOdometer"))
-                {
-                    ushort tripOdometer = (sender as OWBoard).TripOdometer;
-                    string tripDescription = RotationsToDistanceConverter.ConvertRotationsToDistance(tripOdometer);
-                    watchService.UpdateDistance(tripDescription);
-                }
+                Instance.UpdateProperty(e.PropertyName, (sender as OWBoard));
             }
             catch (Exception ex)
             {
@@ -51,6 +76,29 @@ namespace OWCE.PropertyChangeHandlers
                 //(sender as OWBoard).ErrorMessage = $"Exception Handling Watch Property Change: {ex.Message}";
             }
 
+        }
+
+        // Invoked when the watch sends messages to the phone (eg when the watch wakes up)
+        public static void HandleWatchMessage(Dictionary<string, object> message, OWBoard board)
+        {
+            try
+            {
+                if (message.ContainsKey("WatchAppAwake"))
+                {
+                    if (board == null)
+                    {
+                        Console.WriteLine("Board not initialized yet. Returning");
+                        return;
+                    }
+                    // Watch just woke up -- send all current data to bring
+                    // the watch up to speed
+                    Instance.UpdateProperty(null, board);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Exception Handling Watch Message: {ex.Message}");
+            }
         }
     }
 }

--- a/OWCE/OWCE/PropertyChangeHandlers/WatchSyncEventHandler.cs
+++ b/OWCE/OWCE/PropertyChangeHandlers/WatchSyncEventHandler.cs
@@ -9,7 +9,8 @@ namespace OWCE.PropertyChangeHandlers
 {
     public class WatchSyncEventHandler
     {
-        private static readonly HashSet<String> PropertiesToWatch = new HashSet<string> { "BatteryPercent", "BatteryVoltage", "RPM", "TripOdometer" };
+        private static readonly HashSet<String> PropertiesToWatch =
+            new HashSet<string> { "BatteryPercent", "BatteryVoltage", "RPM", "TripOdometer" };
 
         public static readonly WatchSyncEventHandler Instance = new WatchSyncEventHandler();
 
@@ -26,31 +27,38 @@ namespace OWCE.PropertyChangeHandlers
 
                 // For Quart, should add battery percent here
             }
+
             if (propertyName == null || propertyName.Equals("RPM"))
             {
                 int rpm = board.RPM;
                 int speed = (int)RpmToSpeedConverter.ConvertFromRpm(rpm);
                 watchUpdates.Add("Speed", speed);
             }
+
             if (propertyName == null || propertyName.Equals("BatteryPercent"))
             {
                 int batteryPercent = board.BatteryPercent;
                 watchUpdates.Add("BatteryPercent", batteryPercent);
             }
+
             if (propertyName == null || propertyName.Equals("TripOdometer"))
             {
                 ushort tripOdometer = board.TripOdometer;
                 string tripDescription = RotationsToDistanceConverter.ConvertRotationsToDistance(tripOdometer);
                 watchUpdates.Add("Distance", tripDescription);
             }
+
             if (propertyName == null)
             {
                 watchUpdates.Add("SpeedUnitsLabel", App.Current.MetricDisplay ? "km/h" : "mph");
             }
-            // TODO: Here we can implement delayed send
+
+            // TODO: In future, consider calling FlushMessages() after a delay
+            // to accumulate more messages and reduce the traffic to the watch.
             FlushMessages();
         }
 
+        // Sends all outstanding updates to the watch, and reset the update Dictionary
         private void FlushMessages()
         {
             var updates = watchUpdates;

--- a/OWCE/OWCE/PropertyChangeHandlers/WatchSyncEventHandler.cs
+++ b/OWCE/OWCE/PropertyChangeHandlers/WatchSyncEventHandler.cs
@@ -23,7 +23,7 @@ namespace OWCE.PropertyChangeHandlers
             if (propertyName == null || propertyName.Equals("BatteryVoltage"))
             {
                 float voltage = board.BatteryVoltage;
-                watchUpdates.Add("Voltage", voltage);
+                watchUpdates["Voltage"] = voltage;
 
                 // For Quart, should add battery percent here
             }
@@ -32,25 +32,25 @@ namespace OWCE.PropertyChangeHandlers
             {
                 int rpm = board.RPM;
                 int speed = (int)RpmToSpeedConverter.ConvertFromRpm(rpm);
-                watchUpdates.Add("Speed", speed);
+                watchUpdates["Speed"] = speed;
             }
 
             if (propertyName == null || propertyName.Equals("BatteryPercent"))
             {
                 int batteryPercent = board.BatteryPercent;
-                watchUpdates.Add("BatteryPercent", batteryPercent);
+                watchUpdates["BatteryPercent"] = batteryPercent;
             }
 
             if (propertyName == null || propertyName.Equals("TripOdometer"))
             {
                 ushort tripOdometer = board.TripOdometer;
                 string tripDescription = RotationsToDistanceConverter.ConvertRotationsToDistance(tripOdometer);
-                watchUpdates.Add("Distance", tripDescription);
+                watchUpdates["Distance"] = tripDescription;
             }
 
             if (propertyName == null)
             {
-                watchUpdates.Add("SpeedUnitsLabel", App.Current.MetricDisplay ? "km/h" : "mph");
+                watchUpdates["SpeedUnitsLabel"] = App.Current.MetricDisplay ? "km/h" : "mph";
             }
 
             // TODO: In future, consider calling FlushMessages() after a delay


### PR DESCRIPTION
This is mainly a refactoring exercise to consolidate some of the watch update code, and moves a lot of the functionality buried under the dependency implementations into the common module. 

Although it doesn't actually fix performance issues, it will help with the following:
- Make it easier to implement batched / throttled updates to the watch (instead of sending 1 message for each property change)
- Make it easier to support WearOS in future, as a lot of logic has been moved to the common layer, leaving the dependency implementations much more lightweight.

It also addresses a bug that is not immediately noticeable: Battery Percent wasn't actually being updated while the app is running (only when app comes into view). Most people won't notice since they don't stare at the watch long enough for the battery to drop by 1 percent
