### PR TITLE
Change the layout for Watch app to be more compact and use more black background

### DIFF
--- a/OWCE/OWCE.WatchOS/OWCE.WatchOS.WatchOSApp/Interface.storyboard
+++ b/OWCE/OWCE.WatchOS/OWCE.WatchOS.WatchOSApp/Interface.storyboard
@@ -30,14 +30,14 @@
                                 <group width="1" alignment="left" id="LmL-Ci-hqA">
                                     <items>
                                         <label height="54" alignment="center" text="0" textAlignment="center" id="jhG-AM-wAb">
-                                            <color key="textColor" red="1" green="0.98420685529999996" blue="0.0028507602399999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <color key="textColor" red="1" green="1" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <fontDescription key="font" name="SairaExtraCondensed-Black" family="Saira ExtraCondensed" pointSize="60"/>
                                             <variation key="device=watch42mm">
                                                 <fontDescription key="font" name="SairaExtraCondensed-Black" family="Saira ExtraCondensed" pointSize="72"/>
                                             </variation>
                                         </label>
                                         <label height="24" alignment="center" verticalAlignment="center" text="mph" textAlignment="center" id="Hmi-dN-68Z">
-                                            <color key="textColor" red="1" green="0.98420685529999996" blue="0.0028507602399999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <color key="textColor" red="1" green="1" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <fontDescription key="font" name="SairaExtraCondensed-Black" family="Saira ExtraCondensed" pointSize="20"/>
                                         </label>
                                     </items>
@@ -45,29 +45,37 @@
                                 <group width="1" alignment="left" id="jAC-3K-vDG">
                                     <items>
                                         <label alignment="left" text="100%" textAlignment="left" numberOfLines="0" id="kEP-RA-nQQ">
-                                            <color key="textColor" red="0.99984914059999996" green="0.037384711209999998" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <color key="textColor" red="1" green="0.39253377374205406" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <fontDescription key="font" name="SairaExtraCondensed-Black" family="Saira ExtraCondensed" pointSize="48"/>
                                             <variation key="device=watch38mm">
                                                 <fontDescription key="font" name="SairaExtraCondensed-Black" family="Saira ExtraCondensed" pointSize="36"/>
                                             </variation>
                                         </label>
                                         <label alignment="right" verticalAlignment="center" text="0.0V" textAlignment="center" id="Y75-iU-HdX">
-                                            <color key="textColor" red="0.99984914059999996" green="0.037384711209999998" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <color key="textColor" red="1" green="0.39215686274509803" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <fontDescription key="font" name="SairaExtraCondensed-Black" family="Saira ExtraCondensed" pointSize="30"/>
                                         </label>
                                     </items>
                                 </group>
-                                <group width="1" alignment="left" layout="vertical" id="0s8-zO-gKM">
-                                    <items>
-                                        <label width="133" height="46" alignment="center" text="0 mi" textAlignment="center" id="aCv-RU-pjH" userLabel="Trip Distance Label">
-                                            <color key="textColor" red="1" green="0.98420685529999996" blue="0.0028507602399999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                            <fontDescription key="font" name="SairaExtraCondensed-Black" family="Saira ExtraCondensed" pointSize="36"/>
-                                        </label>
-                                        <label width="1" height="25" alignment="left" verticalAlignment="center" hidden="YES" text="ride" textAlignment="center" id="zhb-Sf-Nba">
-                                            <color key="textColor" red="1" green="0.98420685529999996" blue="0.0028507602399999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                            <fontDescription key="font" name="SairaExtraCondensed-Black" family="Saira ExtraCondensed" pointSize="20"/>
-                                        </label>
-                                    </items>
+                                <button alignment="left" id="Svw-GX-pd7">
+                                    <group key="contentGroup" width="1" alignment="left" layout="vertical" id="XvD-Ok-iy6">
+                                        <items>
+                                            <label width="133" height="46" alignment="center" text="0 mi" textAlignment="center" id="aCv-RU-pjH" userLabel="Trip Distance Label">
+                                                <color key="textColor" red="1" green="1" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <fontDescription key="font" name="SairaExtraCondensed-Black" family="Saira ExtraCondensed" pointSize="36"/>
+                                            </label>
+                                            <label width="1" height="25" alignment="left" verticalAlignment="center" hidden="YES" text="ride" textAlignment="center" id="zhb-Sf-Nba">
+                                                <color key="textColor" red="1" green="0.98420685529999996" blue="0.0028507602399999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <fontDescription key="font" name="SairaExtraCondensed-Black" family="Saira ExtraCondensed" pointSize="20"/>
+                                            </label>
+                                        </items>
+                                        <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </group>
+                                    <connections>
+                                        <action selector="darkModeTogglePressed" destination="AgC-eL-Hgc" id="zZM-9e-8Wk"/>
+                                    </connections>
+                                </button>
+                                <group width="1" alignment="left" hidden="YES" layout="vertical" id="0s8-zO-gKM">
                                     <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </group>
                                 <label alignment="left" hidden="YES" text="Label" id="rol-Vw-zN9"/>
@@ -77,12 +85,14 @@
                         </group>
                     </items>
                     <connections>
+                        <outlet property="batteryLabelGroup" destination="jAC-3K-vDG" id="rEO-fu-JNm"/>
                         <outlet property="batteryPercentageLabel" destination="kEP-RA-nQQ" id="jHA-RH-Qko"/>
                         <outlet property="connectToBoardGroup" destination="udh-QH-9Jq" id="ysQ-7e-zFN"/>
                         <outlet property="errorMessages" destination="1IU-Bg-Gto" id="CMQ-DF-eT5"/>
                         <outlet property="myLabel" destination="rol-Vw-zN9" id="nd0-Bt-JFx"/>
                         <outlet property="rideDetailsGroup" destination="ZR4-J3-7uD" id="LNV-Z8-gdA"/>
                         <outlet property="speedLabel" destination="jhG-AM-wAb" id="PJ6-Lz-A6L"/>
+                        <outlet property="speedLabelGroup" destination="LmL-Ci-hqA" id="LD1-Gy-w63"/>
                         <outlet property="speedUnitsLabel" destination="Hmi-dN-68Z" id="I8O-sq-d0Y"/>
                         <outlet property="tripDistanceLabel" destination="aCv-RU-pjH" id="wXT-oQ-UWB"/>
                         <outlet property="voltageLabel" destination="Y75-iU-HdX" id="LDC-Mb-J8a"/>

--- a/OWCE/OWCE.WatchOS/OWCE.WatchOS.WatchOSApp/Interface.storyboard
+++ b/OWCE/OWCE.WatchOS/OWCE.WatchOS.WatchOSApp/Interface.storyboard
@@ -16,7 +16,7 @@
             <objects>
                 <controller id="AgC-eL-Hgc" customClass="InterfaceController">
                     <items>
-                        <label width="1" alignment="left" text="OWCE" textAlignment="center" id="ShG-eU-ZCd">
+                        <label width="1" alignment="left" hidden="YES" text="OWCE" textAlignment="center" id="ShG-eU-ZCd">
                             <color key="textColor" red="1" green="0.98420685529999996" blue="0.0028507602399999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         </label>
                         <group width="1" alignment="left" layout="vertical" id="udh-QH-9Jq">
@@ -25,39 +25,45 @@
                                 <label height="78" alignment="left" textAlignment="center" id="dIc-PU-d81"/>
                             </items>
                         </group>
-                        <group width="1" alignment="left" layout="vertical" id="ZR4-J3-7uD">
+                        <group width="1" alignment="left" layout="vertical" spacing="0.0" id="ZR4-J3-7uD">
                             <items>
-                                <group width="1" alignment="left" layout="vertical" id="Uz7-H4-yJd">
+                                <group width="1" alignment="left" id="LmL-Ci-hqA">
                                     <items>
                                         <label height="54" alignment="center" text="0" textAlignment="center" id="jhG-AM-wAb">
-                                            <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <color key="textColor" red="1" green="0.98420685529999996" blue="0.0028507602399999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <fontDescription key="font" name="SairaExtraCondensed-Black" family="Saira ExtraCondensed" pointSize="60"/>
+                                            <variation key="device=watch42mm">
+                                                <fontDescription key="font" name="SairaExtraCondensed-Black" family="Saira ExtraCondensed" pointSize="72"/>
+                                            </variation>
                                         </label>
                                         <label height="24" alignment="center" verticalAlignment="center" text="mph" textAlignment="center" id="Hmi-dN-68Z">
-                                            <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <color key="textColor" red="1" green="0.98420685529999996" blue="0.0028507602399999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <fontDescription key="font" name="SairaExtraCondensed-Black" family="Saira ExtraCondensed" pointSize="20"/>
                                         </label>
                                     </items>
-                                    <color key="backgroundColor" red="1" green="0.98420685529999996" blue="0.0028507602399999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </group>
-                                <group width="1" alignment="left" layout="vertical" id="xHP-lz-dts">
+                                <group width="1" alignment="left" id="jAC-3K-vDG">
                                     <items>
-                                        <label height="54" alignment="center" text="100%" textAlignment="center" id="kEP-RA-nQQ">
-                                            <fontDescription key="font" name="SairaExtraCondensed-Black" family="Saira ExtraCondensed" pointSize="55"/>
+                                        <label alignment="left" text="100%" textAlignment="left" numberOfLines="0" id="kEP-RA-nQQ">
+                                            <color key="textColor" red="0.99984914059999996" green="0.037384711209999998" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <fontDescription key="font" name="SairaExtraCondensed-Black" family="Saira ExtraCondensed" pointSize="48"/>
+                                            <variation key="device=watch38mm">
+                                                <fontDescription key="font" name="SairaExtraCondensed-Black" family="Saira ExtraCondensed" pointSize="36"/>
+                                            </variation>
                                         </label>
-                                        <label alignment="center" text="0.0V battery" textAlignment="center" id="Y75-iU-HdX">
-                                            <fontDescription key="font" name="SairaExtraCondensed-Black" family="Saira ExtraCondensed" pointSize="20"/>
+                                        <label alignment="right" verticalAlignment="center" text="0.0V" textAlignment="center" id="Y75-iU-HdX">
+                                            <color key="textColor" red="0.99984914059999996" green="0.037384711209999998" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <fontDescription key="font" name="SairaExtraCondensed-Black" family="Saira ExtraCondensed" pointSize="30"/>
                                         </label>
                                     </items>
-                                    <color key="backgroundColor" red="0.99984914059999996" green="0.037384711209999998" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </group>
                                 <group width="1" alignment="left" layout="vertical" id="0s8-zO-gKM">
                                     <items>
                                         <label width="133" height="46" alignment="center" text="0 mi" textAlignment="center" id="aCv-RU-pjH" userLabel="Trip Distance Label">
                                             <color key="textColor" red="1" green="0.98420685529999996" blue="0.0028507602399999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                            <fontDescription key="font" name="SairaExtraCondensed-Black" family="Saira ExtraCondensed" pointSize="45"/>
+                                            <fontDescription key="font" name="SairaExtraCondensed-Black" family="Saira ExtraCondensed" pointSize="36"/>
                                         </label>
-                                        <label width="1" height="25" alignment="left" verticalAlignment="center" text="ride" textAlignment="center" id="zhb-Sf-Nba">
+                                        <label width="1" height="25" alignment="left" verticalAlignment="center" hidden="YES" text="ride" textAlignment="center" id="zhb-Sf-Nba">
                                             <color key="textColor" red="1" green="0.98420685529999996" blue="0.0028507602399999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <fontDescription key="font" name="SairaExtraCondensed-Black" family="Saira ExtraCondensed" pointSize="20"/>
                                         </label>
@@ -67,6 +73,7 @@
                                 <label alignment="left" hidden="YES" text="Label" id="rol-Vw-zN9"/>
                                 <label alignment="left" hidden="YES" text="Errors:" numberOfLines="10" id="1IU-Bg-Gto"/>
                             </items>
+                            <edgeInsets key="margins" left="0.0" right="0.0" top="0.0" bottom="0.0"/>
                         </group>
                     </items>
                     <connections>
@@ -82,7 +89,7 @@
                     </connections>
                 </controller>
             </objects>
-            <point key="canvasLocation" x="0.0" y="-153.5"/>
+            <point key="canvasLocation" x="0.0" y="-153.87179487179489"/>
         </scene>
         <!--Static Notification Interface Controller-->
         <scene sceneID="AEw-b0-oYE">

--- a/OWCE/OWCE.WatchOS/OWCE.WatchOS.WatchOSExtension/InterfaceController.cs
+++ b/OWCE/OWCE.WatchOS/OWCE.WatchOS.WatchOSExtension/InterfaceController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Foundation;
+using UIKit;
 using WatchConnectivity;
 using WatchKit;
 
@@ -16,6 +17,8 @@ namespace OWCE.WatchOS.WatchOSExtension
         {
             // Note: this .ctor should not contain any initialization logic.
         }
+
+        private bool darkMode = true;
 
         public override void Awake(NSObject context)
         {
@@ -130,6 +133,46 @@ namespace OWCE.WatchOS.WatchOSExtension
             this.rideDetailsGroup.SetHidden(false);
 
         }
+
+        private void toggleBatteryPressed()
+        {
+            if (darkMode)
+            {
+                // Set Battery Labels to Light Mode
+                this.batteryLabelGroup.SetBackgroundColor(UIColor.Magenta);
+                this.batteryPercentageLabel.SetTextColor(UIColor.White);
+                this.voltageLabel.SetTextColor(UIColor.White);
+
+                // Set Speed Labels to Light mode
+                this.speedLabelGroup.SetBackgroundColor(UIColor.Yellow);
+                this.speedLabel.SetTextColor(UIColor.Black);
+                this.speedUnitsLabel.SetTextColor(UIColor.Black);
+
+                darkMode = false;
+            }
+            else
+            {
+                // Set Battery Labels to Dark Mode
+                this.batteryLabelGroup.SetBackgroundColor(UIColor.Black);
+                // Note: the battery labels are a whiter version of
+                // Magenta to make it more readable
+                this.batteryPercentageLabel.SetTextColor(UIColor.FromRGB(255, 100, 255));
+                this.voltageLabel.SetTextColor(UIColor.FromRGB(255, 100, 255));
+
+                // Set Speed Labels to Dark Mode
+                this.speedLabelGroup.SetBackgroundColor(UIColor.Black);
+                this.speedLabel.SetTextColor(UIColor.Yellow);
+                this.speedUnitsLabel.SetTextColor(UIColor.Yellow);
+
+                darkMode = true;
+            }
+        }
+
+        partial void darkModeTogglePressed()
+        {
+            toggleBatteryPressed();
+        }
+
     }
 }
 

--- a/OWCE/OWCE.WatchOS/OWCE.WatchOS.WatchOSExtension/InterfaceController.cs
+++ b/OWCE/OWCE.WatchOS/OWCE.WatchOS.WatchOSExtension/InterfaceController.cs
@@ -96,7 +96,7 @@ namespace OWCE.WatchOS.WatchOSExtension
                 }
                 if (applicationContext.ContainsKey("Voltage"))
                 {
-                    this.voltageLabel.SetText(String.Format("{0:F2}V battery", applicationContext["Voltage"]));
+                    this.voltageLabel.SetText(String.Format("{0:F2}V", applicationContext["Voltage"]));
                 }
                 if (applicationContext.ContainsKey("Distance"))
                 {

--- a/OWCE/OWCE.WatchOS/OWCE.WatchOS.WatchOSExtension/InterfaceController.designer.cs
+++ b/OWCE/OWCE.WatchOS/OWCE.WatchOS.WatchOSExtension/InterfaceController.designer.cs
@@ -13,6 +13,9 @@ namespace OWCE.WatchOS.WatchOSExtension
 	partial class InterfaceController
 	{
 		[Outlet]
+		WatchKit.WKInterfaceGroup batteryLabelGroup { get; set; }
+
+		[Outlet]
 		WatchKit.WKInterfaceLabel batteryPercentageLabel { get; set; }
 
 		[Outlet]
@@ -31,6 +34,9 @@ namespace OWCE.WatchOS.WatchOSExtension
 		WatchKit.WKInterfaceLabel speedLabel { get; set; }
 
 		[Outlet]
+		WatchKit.WKInterfaceGroup speedLabelGroup { get; set; }
+
+		[Outlet]
 		WatchKit.WKInterfaceLabel speedUnitsLabel { get; set; }
 
 		[Outlet]
@@ -38,12 +44,25 @@ namespace OWCE.WatchOS.WatchOSExtension
 
 		[Outlet]
 		WatchKit.WKInterfaceLabel voltageLabel { get; set; }
+
+		[Action ("darkModeTogglePressed")]
+		partial void darkModeTogglePressed ();
 		
 		void ReleaseDesignerOutlets ()
 		{
+			if (batteryLabelGroup != null) {
+				batteryLabelGroup.Dispose ();
+				batteryLabelGroup = null;
+			}
+
 			if (batteryPercentageLabel != null) {
 				batteryPercentageLabel.Dispose ();
 				batteryPercentageLabel = null;
+			}
+
+			if (connectToBoardGroup != null) {
+				connectToBoardGroup.Dispose ();
+				connectToBoardGroup = null;
 			}
 
 			if (errorMessages != null) {
@@ -56,9 +75,19 @@ namespace OWCE.WatchOS.WatchOSExtension
 				myLabel = null;
 			}
 
+			if (rideDetailsGroup != null) {
+				rideDetailsGroup.Dispose ();
+				rideDetailsGroup = null;
+			}
+
 			if (speedLabel != null) {
 				speedLabel.Dispose ();
 				speedLabel = null;
+			}
+
+			if (speedLabelGroup != null) {
+				speedLabelGroup.Dispose ();
+				speedLabelGroup = null;
 			}
 
 			if (speedUnitsLabel != null) {
@@ -74,16 +103,6 @@ namespace OWCE.WatchOS.WatchOSExtension
 			if (voltageLabel != null) {
 				voltageLabel.Dispose ();
 				voltageLabel = null;
-			}
-
-			if (connectToBoardGroup != null) {
-				connectToBoardGroup.Dispose ();
-				connectToBoardGroup = null;
-			}
-
-			if (rideDetailsGroup != null) {
-				rideDetailsGroup.Dispose ();
-				rideDetailsGroup = null;
 			}
 		}
 	}


### PR DESCRIPTION
Changes the layout of the watch app to fit everything on one screen and use more of the black background which should be more battery efficient.

<img width="937" alt="WatchCompactLayout" src="https://user-images.githubusercontent.com/86817367/131953085-785b7014-465b-4868-95b1-bb86c778ef99.png">

Also added an option where if you click on the distance label, it toggles dark / light mode. Screenshots below:

![IMG_1319 (1)](https://user-images.githubusercontent.com/86817367/132081190-1c2d7009-d0bf-4c74-986d-39889d39eefb.jpeg)
![IMG_1318 (1)](https://user-images.githubusercontent.com/86817367/132081192-9b958540-fd88-4a74-bfbf-3fa6ed0c2cb1.jpeg)


This is the layout that I'm using locally now, and I think it works reasonably well. It's obviously subjective whether we want to adopt this for the next release of the app, but putting it out there to see if you want to merge this in.  