### PR TITLE
Added support to Rewheel'd GTs with BLE handshake patch

### DIFF
--- a/OWCE/OWCE/Models/BatteryCells.cs
+++ b/OWCE/OWCE/Models/BatteryCells.cs
@@ -26,6 +26,10 @@ namespace OWCE.Models
         public string BatteryCell13 { get; private set; } = "-";
         public string BatteryCell14 { get; private set; } = "-";
         public string BatteryCell15 { get; private set; } = "-";
+        public string BatteryCell16 { get; private set; } = "-";
+        public string BatteryCell17 { get; private set; } = "-";
+        public string BatteryCell18 { get; private set; } = "-";
+
 
 
         private Dictionary<uint, float> _cells = new Dictionary<uint, float>();
@@ -261,6 +265,27 @@ namespace OWCE.Models
                     {
                         BatteryCell15 = voltageString;
                         OnPropertyChanged("BatteryCell15");
+                    }
+                    break;
+                case 16:
+                    if (BatteryCell16 != voltageString)
+                    {
+                        BatteryCell16 = voltageString;
+                        OnPropertyChanged("BatteryCell16");
+                    }
+                    break;
+                case 17:
+                    if (BatteryCell17 != voltageString)
+                    {
+                        BatteryCell17 = voltageString;
+                        OnPropertyChanged("BatteryCell17");
+                    }
+                    break;
+                case 18:
+                    if (BatteryCell18 != voltageString)
+                    {
+                        BatteryCell18 = voltageString;
+                        OnPropertyChanged("BatteryCell18");
                     }
                     break;
             }

--- a/OWCE/OWCE/OWBaseBoard.cs
+++ b/OWCE/OWCE/OWBaseBoard.cs
@@ -266,6 +266,19 @@ namespace OWCE
                     ("Skyline", RideModes.Pint_Skyline),
                 };
             }
+            else if (_boardType == OWBoardType.GT)
+            {
+                return new List<(string, ushort)>()
+                {
+                    ("Bay", RideModes.GT_Bay),
+                    ("Roam", RideModes.GT_Roam),
+                    ("Flow", RideModes.GT_Flow),
+                    ("Highline", RideModes.GT_HighLine),
+                    ("Elevated", RideModes.GT_Elevated),
+                    ("Apex", RideModes.GT_Apex),
+                    ("Custom", RideModes.GT_Custom),
+                };
+            }
 
             return new List<(string, ushort)>();
         }

--- a/OWCE/OWCE/Views/BatteryCellsView.cs
+++ b/OWCE/OWCE/Views/BatteryCellsView.cs
@@ -79,6 +79,11 @@ namespace OWCE.Views
                     rows = 4;
                     columns = 4;
                 }
+                else if (batteryCells.CellCount == 18)
+                {
+                    rows = 6;
+                    columns = 3;
+                }
                 else
                 {
                     return;

--- a/OWCE/OWCE/Views/BatteryView.xaml
+++ b/OWCE/OWCE/Views/BatteryView.xaml
@@ -5,12 +5,26 @@
     xmlns:xct="clr-namespace:Xamarin.CommunityToolkit.UI.Views;assembly=Xamarin.CommunityToolkit"
     xmlns:yummy="clr-namespace:Xamarin.Forms.PancakeView;assembly=Xamarin.Forms.PancakeView"
     xmlns:views="clr-namespace:OWCE.Views"
+    xmlns:converters="clr-namespace:OWCE.Converters"
     x:Class="OWCE.Views.BatteryView">
+
+    <ContentView.Resources>
+        <converters:AnyTrueMultiConverter x:Key="AnyTrueConverter" />
+        <converters:IsBoardTypeConverter x:Key="IsBoardTypeConverter" />
+    </ContentView.Resources>
 
     <yummy:PancakeView x:Name="MainView" BackgroundColor="#FFFF00" Style="{StaticResource BoardDetailBlockBaseStyle}" >
 
 
         <xct:Expander x:Name="ExpanderView" HorizontalOptions="Fill" PropertyChanged="ExpanderView_PropertyChanged">
+            <xct:Expander.IsEnabled>
+                <MultiBinding Converter="{StaticResource AnyTrueConverter}">
+                    <Binding Path="BoardType" Converter="{StaticResource IsBoardTypeConverter}" ConverterParameter="V1" />
+                    <Binding Path="BoardType" Converter="{StaticResource IsBoardTypeConverter}" ConverterParameter="Plus" />
+                    <Binding Path="BoardType" Converter="{StaticResource IsBoardTypeConverter}" ConverterParameter="XR" />
+                    <Binding Path="BoardType" Converter="{StaticResource IsBoardTypeConverter}" ConverterParameter="Pint" />
+                </MultiBinding>
+            </xct:Expander.IsEnabled>
             <xct:Expander.Header>
                 <Grid BackgroundColor="#CC00CC" RowDefinitions="121" AbsoluteLayout.LayoutFlags="WidthProportional" AbsoluteLayout.LayoutBounds="0,0,1,121">
 
@@ -21,6 +35,14 @@
                     <Label Text="{Binding BatteryPercent, StringFormat='{0}%'}"  TextColor="White"  FontFamily="SairaExtraCondensed-Black" FontSize="80" HorizontalOptions="Center" VerticalOptions="Start"  />
 
                     <Label VerticalOptions="End" Margin="20,0">
+                        <Label.IsVisible>
+                            <MultiBinding Converter="{StaticResource AnyTrueConverter}">
+                                <Binding Path="BoardType" Converter="{StaticResource IsBoardTypeConverter}" ConverterParameter="V1" />
+                                <Binding Path="BoardType" Converter="{StaticResource IsBoardTypeConverter}" ConverterParameter="Plus" />
+                                <Binding Path="BoardType" Converter="{StaticResource IsBoardTypeConverter}" ConverterParameter="XR" />
+                                <Binding Path="BoardType" Converter="{StaticResource IsBoardTypeConverter}" ConverterParameter="Pint" />
+                            </MultiBinding>
+                        </Label.IsVisible>
                         <Label.FormattedText>
                             <FormattedString>
                                 <Span Text="{Binding BatteryCells.LowestCellVoltage, StringFormat='{0:F2}-'}" FontSize="16" TextColor="White" FontFamily="SairaExtraCondensed-Medium" />
@@ -30,10 +52,28 @@
                         </Label.FormattedText>
                     </Label>
 
-                    <Label Text="{Binding BatteryVoltage, StringFormat='{0:F2}V'}" TextColor="White" FontSize="16" FontFamily="SairaExtraCondensed-Medium" HorizontalTextAlignment="End" HorizontalOptions="Fill" VerticalOptions="End" Margin="20,0" />
+                    <Label Text="{Binding BatteryVoltage, StringFormat='{0:F2}V'}" TextColor="White" FontSize="16" FontFamily="SairaExtraCondensed-Medium" HorizontalTextAlignment="End" HorizontalOptions="Fill" VerticalOptions="End" Margin="20,0" >
+                        <Label.IsVisible>
+                            <MultiBinding Converter="{StaticResource AnyTrueConverter}">
+                                <Binding Path="BoardType" Converter="{StaticResource IsBoardTypeConverter}" ConverterParameter="V1" />
+                                <Binding Path="BoardType" Converter="{StaticResource IsBoardTypeConverter}" ConverterParameter="Plus" />
+                                <Binding Path="BoardType" Converter="{StaticResource IsBoardTypeConverter}" ConverterParameter="XR" />
+                                <Binding Path="BoardType" Converter="{StaticResource IsBoardTypeConverter}" ConverterParameter="Pint" />
+                            </MultiBinding>
+                        </Label.IsVisible>
+                    </Label>
 
 
-                    <views:ExpanderArrowView x:Name="ExpanderArrow" HorizontalOptions="End" Margin="17,13" />
+                    <views:ExpanderArrowView x:Name="ExpanderArrow" HorizontalOptions="End" Margin="17,13" >
+                        <views:ExpanderArrowView.IsVisible>
+                             <MultiBinding Converter="{StaticResource AnyTrueConverter}">
+                                <Binding Path="BoardType" Converter="{StaticResource IsBoardTypeConverter}" ConverterParameter="V1" />
+                                <Binding Path="BoardType" Converter="{StaticResource IsBoardTypeConverter}" ConverterParameter="Plus" />
+                                <Binding Path="BoardType" Converter="{StaticResource IsBoardTypeConverter}" ConverterParameter="XR" />
+                                <Binding Path="BoardType" Converter="{StaticResource IsBoardTypeConverter}" ConverterParameter="Pint" />
+                            </MultiBinding>
+                        </views:ExpanderArrowView.IsVisible>
+                     </views:ExpanderArrowView>
 
                 </Grid>
 

--- a/OWCE/OWCE/Views/RideModeView.xaml
+++ b/OWCE/OWCE/Views/RideModeView.xaml
@@ -86,6 +86,7 @@
                         <MultiBinding Converter="{StaticResource AnyTrueConverter}">
                             <Binding Path="BoardType" Converter="{StaticResource IsBoardTypeConverter}" ConverterParameter="Plus" />
                             <Binding Path="BoardType" Converter="{StaticResource IsBoardTypeConverter}" ConverterParameter="XR" />
+                            <Binding Path="BoardType" Converter="{StaticResource IsBoardTypeConverter}" ConverterParameter="GT" />
                         </MultiBinding>
                     </Button.IsVisible>
                 </Button>


### PR DESCRIPTION
- Added support for GT board (HW, FW > 6000). Board must have been patched with Rewheel to remove BLE Handshake.
- Disabled KeepBoardAlive for HW>6000 since BLE patched Rewheel GT do not need unlocking (nor the lock)
- Added the GT Ride Modes
- Disabled the Battery Voltage and cell voltage readings on the UI since they cannot be read (for now) in a GT even if it has been Rewheeld. Added the GT settings though, i.e.: it being an 18S battery etc... just in case we get that in a Rewheel patch in the future that broadcasts this information.