### PR TITLE
Support to read/write Board Key and Token

### DIFF
--- a/OWCE/OWCE/BoardSecureStorage.cs
+++ b/OWCE/OWCE/BoardSecureStorage.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xamarin.Essentials;
+
+namespace OWCE
+{
+    public class BoardSecureStorage
+    {
+        public static Task<string> GetBoardKeyAsync(string board)
+            => GetAsync(board, "key");
+
+        public static Task SetBoardKeyAsync(string board, string value)
+            => SetAsync(board, "key", value);
+
+        public static bool RemoveBoardKey(string board)
+            => Remove(board, "key");
+        public static Task<string> GetBoardTokenAsync(string board)
+            => GetAsync(board, "token");
+        public static Task<bool> HasBoardTokenAsync(string board)
+            => GetAsync(board, "token").ContinueWith(token => !String.IsNullOrEmpty(token.Result));
+
+        public static Task SetBoardTokenAsync(string board, string value)
+            => SetAsync(board, "token", value);
+
+        public static bool RemoveBoardToken(string board)
+            => Remove(board, "token");
+
+        private static Task<string> GetAsync(string board, string entry)
+            => SecureStorage.GetAsync(EntryKey(board, entry));
+
+        private static Task SetAsync(string board, string entry, string value)
+            => SecureStorage.SetAsync(EntryKey(board, entry), value);
+
+        private static bool Remove(string board, string entry)
+            => SecureStorage.Remove(EntryKey(board, entry));
+
+        private static string EntryKey(string board, string entry)
+        {
+            if (string.IsNullOrWhiteSpace(board))
+                throw new ArgumentNullException(nameof(board));
+
+            string deviceName = board.ToLower();
+            string deviceId = deviceName.Replace("ow", String.Empty);
+
+            return $"board_{deviceId}_{entry}";
+        }
+    }
+}

--- a/OWCE/OWCE/Pages/BoardListPage.xaml
+++ b/OWCE/OWCE/Pages/BoardListPage.xaml
@@ -9,6 +9,7 @@
              xmlns:views="clr-namespace:OWCE.Views"
              xmlns:popup="clr-namespace:OWCE.Pages.Popup"
              x:DataType="pages:BoardListPage"
+             xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
              xmlns:xcte="clr-namespace:Xamarin.CommunityToolkit.Effects;assembly=Xamarin.CommunityToolkit">
     <ContentPage.Resources>
         <ResourceDictionary>
@@ -55,8 +56,8 @@
                 <CollectionView.ItemTemplate>
                     <DataTemplate x:DataType="owce:OWBaseBoard">
                         <ContentView Padding="16,10,16,15">
-                           
-                            <yummy:PancakeView HeightRequest="121" CornerRadius="11" BackgroundColor="{StaticResource BrightYellow}" xcte:TouchEffect.NativeAnimation="true" xcte:TouchEffect.Command="{Binding Source={x:Reference MainCollectionView}, Path=BindingContext.BoardSelectedCommand}" xcte:TouchEffect.CommandParameter="{Binding .}" >
+
+                            <yummy:PancakeView HeightRequest="121" CornerRadius="11" BackgroundColor="{StaticResource BrightYellow}" xcte:TouchEffect.NativeAnimation="true" xcte:TouchEffect.Command="{Binding Source={x:Reference MainCollectionView}, Path=BindingContext.BoardSelectedCommand}"  xcte:TouchEffect.LongPressCommand="{Binding Source={x:Reference MainCollectionView}, Path=BindingContext.BoardLongPressCommand}" xcte:TouchEffect.CommandParameter="{Binding .}" >
 
                                 
                                 <yummy:PancakeView.Shadow>

--- a/OWCE/OWCE/Pages/BoardListPage.xaml.cs
+++ b/OWCE/OWCE/Pages/BoardListPage.xaml.cs
@@ -64,8 +64,9 @@ namespace OWCE.Pages
         AsyncCommand<OWBaseBoard> _boardSelectedCommand;
         public AsyncCommand<OWBaseBoard> BoardSelectedCommand => _boardSelectedCommand ??= new AsyncCommand<OWBaseBoard>(BoardSelectedAsync, allowsMultipleExecutions: false);
 
-       
-        
+
+        AsyncCommand<OWBaseBoard> _boardLongPressCommand;
+        public AsyncCommand<OWBaseBoard> BoardLongPressCommand => _boardLongPressCommand ??= new AsyncCommand<OWBaseBoard>(BoardLongPressAsync, allowsMultipleExecutions: false);
 
         /*
 
@@ -336,9 +337,21 @@ namespace OWCE.Pages
         }
         */
 
+        async Task BoardLongPressAsync(OWBaseBoard baseBoard)
+        {
+            if (baseBoard == null || !baseBoard.IsAvailable)
+            {
+                return;
+            }
 
+            var key = await BoardSecureStorage.GetBoardKeyAsync(baseBoard.Name);
+            var token = await BoardSecureStorage.GetBoardTokenAsync(baseBoard.Name);
+            var popup = new Pages.Popup.BoadTokenPopup(baseBoard, key, token);
 
+            await PopupNavigation.Instance.PushAsync(popup, true);
 
+            return;
+        }
 
         async Task BoardSelectedAsync(OWBaseBoard baseBoard)
         {

--- a/OWCE/OWCE/Pages/Popup/BoadTokenPopup.xaml
+++ b/OWCE/OWCE/Pages/Popup/BoadTokenPopup.xaml
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<pages:PopupPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:pages="clr-namespace:Rg.Plugins.Popup.Pages;assembly=Rg.Plugins.Popup"
+    xmlns:animations="clr-namespace:Rg.Plugins.Popup.Animations;assembly=Rg.Plugins.Popup"
+    xmlns:yummy="clr-namespace:Xamarin.Forms.PancakeView;assembly=Xamarin.Forms.PancakeView"
+    x:Class="OWCE.Pages.Popup.BoadTokenPopup"
+    CloseWhenBackgroundIsClicked="true"
+    BackgroundColor="#BF000000"
+    Title="Board Token">
+
+    <pages:PopupPage.Animation>
+        <animations:ScaleAnimation
+            PositionIn="Center"
+            PositionOut="Center"
+            ScaleIn="1.2"
+            ScaleOut="0.8"
+            DurationIn="400"
+            DurationOut="300"
+            EasingIn="SinOut"
+            EasingOut="SinIn"
+            HasBackgroundAnimation="True"/>
+    </pages:PopupPage.Animation>
+
+    <yummy:PancakeView Margin="16,0" VerticalOptions="Center" CornerRadius="11" BackgroundColor="{StaticResource BrightYellow}">
+        <Grid RowDefinitions="Auto,Auto,Auto,70" ColumnSpacing="0" RowSpacing="0">
+            <Label Grid.Row="0" Text="{Binding BoardName}" FontFamily="SairaExtraCondensed-Bold" TextColor="Black" FontSize="16" CharacterSpacing="-0.26" Margin="22,5,22,0" VerticalOptions="Start" />
+
+            <Entry Grid.Row="1" Text="{Binding BoardKey}" FontFamily="SairaExtraCondensed-Black" TextColor="Black" FontSize="20" VerticalOptions="Center" HorizontalTextAlignment="Center" Placeholder="Board Key" />
+            <Entry Grid.Row="2" Text="{Binding BoardToken}" FontFamily="SairaExtraCondensed-Black" TextColor="Black" FontSize="20" VerticalOptions="Center" HorizontalTextAlignment="Center" Placeholder="Board Token" />
+
+            <Grid Grid.Row="3" BackgroundColor="White" HeightRequest="70">
+                <Button Text="Save" Style="{StaticResource RoundButtonStyle}" HorizontalOptions="CenterAndExpand" WidthRequest="112" Command="{Binding SaveButtonCommand}" CommandParameter="{Binding .}" />
+            </Grid>
+        </Grid>
+    </yummy:PancakeView>
+</pages:PopupPage>

--- a/OWCE/OWCE/Pages/Popup/BoadTokenPopup.xaml.cs
+++ b/OWCE/OWCE/Pages/Popup/BoadTokenPopup.xaml.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using Rg.Plugins.Popup.Pages;
+using Xamarin.Forms;
+
+namespace OWCE.Pages.Popup
+{
+    public partial class BoadTokenPopup : PopupPage
+    {
+        private readonly Command _saveButtonCommand;
+
+        public String BoardKey { get; set; }
+
+        public String BoardName { get; set; }
+
+        private string _BoardToken;
+        public string BoardToken
+        {
+            get => _BoardToken;
+            set
+            {
+                _BoardToken = value;
+                // Only token is required, OWCE will read the key durring the handshake and save it for the next time.
+                IsSaveButtonEnabled = !String.IsNullOrEmpty(value);
+                this.OnPropertyChanged(nameof(BoardToken));
+            }
+        }
+
+
+        private bool _IsSaveButtonEnabled;
+        public bool IsSaveButtonEnabled
+        {
+            get => _IsSaveButtonEnabled;
+            set
+            {
+                _IsSaveButtonEnabled = value;
+                this.OnPropertyChanged(nameof(IsSaveButtonEnabled));
+            }
+        }
+
+        public Command SaveButtonCommand => _saveButtonCommand;
+
+        public BoadTokenPopup(OWBaseBoard board, String key, String token)
+        {
+            BoardKey = key;
+            BoardToken = token;
+            BoardName = board.Name;
+
+            BindingContext = this;
+            _saveButtonCommand = new Command(async () =>
+            {
+                if (String.IsNullOrWhiteSpace(BoardKey))
+                {
+                    BoardSecureStorage.RemoveBoardKey(BoardName);
+                }
+                else
+                {
+                    await BoardSecureStorage.SetBoardKeyAsync(BoardName, BoardKey.Trim());
+                }
+
+                if (String.IsNullOrWhiteSpace(BoardToken))
+                {
+                    BoardSecureStorage.RemoveBoardToken(BoardName);
+                }
+                else
+                {
+                    await BoardSecureStorage.SetBoardTokenAsync(BoardName, BoardToken.Trim());
+                }
+
+                await Rg.Plugins.Popup.Services.PopupNavigation.Instance.RemovePageAsync(this);
+            });
+
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
Hi,
Thanks for the work on OWCE..


This PR adds support to read/write the board key and token,
With this changes is possible to manually enter the board key/token and use that for the handshake.

Long pressing the board in the board list page will display the `BoadTokenPopup` page where you can see the current key/token for a board or manually enter one.

<br/>
<img src="https://github.com/OnewheelCommunityEdition/OWCE_App/assets/588172/90f55e06-d4ce-46c2-86b6-55c939122add" width="400" height="400">
<img src="https://github.com/OnewheelCommunityEdition/OWCE_App/assets/588172/7040eb3e-0952-4f3f-9660-2c598bcd57f1" width="400" height="400">
Only the token is required,  the key will be read as part of the first handshake..


<br/><br/>

During the handshake OWCE will used the saved token if there is one set.
<img src="https://github.com/OnewheelCommunityEdition/OWCE_App/assets/588172/2d909b78-9e42-4bc0-809b-bf9007f2ef6e" width="400" height="800">

<br/>

This should allow OWCE to connect to any board as long as the user has the token.

In my case I wrote some Ardunino/Esp32 code that reads the token from the app (Will share here if wanted.. Needs some cleanup first) .
But there are probably other ways to get access to it.

I'be been using this with a non Rewheel'd GT.
